### PR TITLE
Change auth providers and verify user accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 notes.md
 private.key
 publickey.pem
+.idea
+*.iml

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::MAX_LOBBY_SIZE,
     jwt::{errors::JwtError, IdToken},
-    AppConfig, GithubOAuthClient, SessionId, SessionInfo, SharedState, SiweAuthClient,
+    AppConfig, GithubOAuthClient, SessionId, SessionInfo, SharedState, SiweOAuthClient,
 };
 use axum::response::Response;
 use axum::{extract::Query, response::IntoResponse, Extension, Json};
@@ -121,7 +121,7 @@ impl IntoResponse for AuthError {
 // in order to get an authorisation code
 pub(crate) async fn auth_client_string(
     Extension(store): Extension<SharedState>,
-    Extension(siwe_client): Extension<SiweAuthClient>,
+    Extension(siwe_client): Extension<SiweOAuthClient>,
     Extension(gh_client): Extension<GithubOAuthClient>,
 ) -> Result<AuthUrl, AuthError> {
     // Fist check if the lobby is full before giving users an auth link
@@ -236,7 +236,7 @@ pub(crate) async fn siwe_callback(
     Query(payload): Query<AuthPayload>,
     Extension(config): Extension<AppConfig>,
     Extension(store): Extension<SharedState>,
-    Extension(oauth_client): Extension<SiweAuthClient>,
+    Extension(oauth_client): Extension<SiweOAuthClient>,
     Extension(http_client): Extension<reqwest::Client>,
 ) -> Result<UserVerified, AuthError> {
     verify_csrf(&payload, &store).await?;

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -211,7 +211,7 @@ pub(crate) async fn github_callback(
         return Err(AuthError::UserCreatedAfterDeadline);
     }
     let user = AuthenticatedUser {
-        uid: format!("gh::{}", gh_user_info.login),
+        uid: format!("github | {}", gh_user_info.login),
         nickname: gh_user_info.login,
     };
     post_authenticate(store, user, AuthProvider::Github).await
@@ -266,19 +266,19 @@ pub(crate) async fn siwe_callback(
 
     let tx_count = get_tx_count(
         &address,
-        &config.eth_max_first_transaction_block,
+        &config.eth_check_nonce_at_block,
         &http_client,
         &config,
     )
     .await
     .ok_or(AuthError::CouldNotExtractUserData)?;
 
-    if tx_count < 1 {
+    if tx_count < config.eth_min_nonce {
         return Err(AuthError::UserCreatedAfterDeadline);
     }
 
     let user_data = AuthenticatedUser {
-        uid: format!("siwe::{}", address),
+        uid: format!("eth | {}", address),
         nickname: siwe_user.preferred_username,
     };
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,3 @@
-use chrono::{DateTime, FixedOffset};
-
 // In seconds, This is the amount of time that
 // a contributor has to complete their contribution
 pub const COMPUTE_DEADLINE: usize = 180;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,5 +29,11 @@ pub const GITHUB_OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/callback
 pub const GITHUB_OAUTH_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
 pub const GITHUB_OAUTH_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 
+// The latest time for creating a Github account eligible for participation
 pub const GITHUB_ACCOUNT_CREATION_DEADLINE: &str = "2022-08-01T00:00:00Z";
-pub const ETH_FIRST_TRANSACTION_DEADLINE: &str = "0xE4D540";
+
+// The hex block number at which we require participants to have a certain nonce
+pub const ETH_CHECK_NONCE_AT_BLOCK: &str = "0xE4D540";
+
+// The minimum nonce we require from eligible participants
+pub const ETH_MIN_NONCE: i64 = 4;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -21,12 +21,13 @@ pub const HISTORY_RECEIPTS_COUNT: usize = 20;
 // This constant defines how often we check, In seconds
 pub const LOBBY_FLUSH_INTERVAL: usize = 5;
 
-pub const OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/authorized";
-pub const OAUTH_AUTH_URL: &str = "https://kev-kzg-ceremony.eu.auth0.com/authorize";
-pub const OAUTH_TOKEN_URL: &str = "https://kev-kzg-ceremony.eu.auth0.com/oauth/token";
+pub const SIWE_OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/callback/siwe";
+pub const SIWE_OAUTH_AUTH_URL: &str = "https://oidc.signinwithethereum.org/authorize";
+pub const SIWE_OAUTH_TOKEN_URL: &str = "https://oidc.signinwithethereum.org/token";
 
 pub const GITHUB_OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/callback/github";
 pub const GITHUB_OAUTH_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
 pub const GITHUB_OAUTH_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 
 pub const GITHUB_ACCOUNT_CREATION_DEADLINE: &str = "2022-08-01T00:00:00Z";
+pub const ETH_FIRST_TRANSACTION_DEADLINE: &str = "0xE4D540";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, FixedOffset};
+
 // In seconds, This is the amount of time that
 // a contributor has to complete their contribution
 pub const COMPUTE_DEADLINE: usize = 180;
@@ -21,6 +23,12 @@ pub const HISTORY_RECEIPTS_COUNT: usize = 20;
 // This constant defines how often we check, In seconds
 pub const LOBBY_FLUSH_INTERVAL: usize = 5;
 
-pub const OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3002/auth/authorized";
+pub const OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/authorized";
 pub const OAUTH_AUTH_URL: &str = "https://kev-kzg-ceremony.eu.auth0.com/authorize";
 pub const OAUTH_TOKEN_URL: &str = "https://kev-kzg-ceremony.eu.auth0.com/oauth/token";
+
+pub const GITHUB_OAUTH_REDIRECT_URL: &str = "http://127.0.0.1:3000/auth/callback/github";
+pub const GITHUB_OAUTH_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
+pub const GITHUB_OAUTH_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+
+pub const GITHUB_ACCOUNT_CREATION_DEADLINE: &str = "2022-08-01T00:00:00Z";

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use sessions::{SessionId, SessionInfo};
 
 use crate::api::v1::auth::{github_callback, siwe_callback};
 use crate::api::v1::{
-    auth::auth_client_string,
+    auth::auth_client_link,
     contribute::contribute,
     info::{current_state, jwt_info, status},
     slot::slot_join,
@@ -56,7 +56,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/hello_world", get(hello_world))
-        .route("/auth/request_link", get(auth_client_string))
+        .route("/auth/request_link", get(auth_client_link))
         .route("/auth/callback/github", get(github_callback))
         .route("/auth/callback/siwe", get(siwe_callback))
         .route("/slot/join", post(slot_join))

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use chrono::{DateTime, FixedOffset};
 use constants::{
     LOBBY_CHECKIN_DEADLINE, LOBBY_FLUSH_INTERVAL, OAUTH_AUTH_URL, OAUTH_REDIRECT_URL,
     OAUTH_TOKEN_URL,
@@ -65,6 +66,7 @@ async fn main() {
         .layer(Extension(shared_state))
         .layer(Extension(oauth_client))
         .layer(Extension(github_oauth_client()))
+        .layer(Extension(AppConfig::default()))
         .layer(Extension(transcript));
 
     let addr = "[::]:3000".parse().unwrap();
@@ -126,6 +128,22 @@ fn github_oauth_client() -> GithubOAuthClient {
 
 async fn hello_world() -> Html<&'static str> {
     Html("<h1>Server is Running</h1>")
+}
+
+#[derive(Clone)]
+pub(crate) struct AppConfig {
+    github_max_creation_time: DateTime<FixedOffset>,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        AppConfig {
+            github_max_creation_time: DateTime::parse_from_rfc3339(
+                constants::GITHUB_ACCOUNT_CREATION_DEADLINE,
+            )
+            .unwrap(),
+        }
+    }
 }
 
 type IdTokenSub = String;

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ async fn hello_world() -> Html<&'static str> {
 #[derive(Clone)]
 pub(crate) struct AppConfig {
     github_max_creation_time: DateTime<FixedOffset>,
-    eth_max_first_transaction_block: String,
+    eth_check_nonce_at_block: String,
+    eth_min_nonce: i64,
     eth_rpc_url: String,
 }
 
@@ -161,7 +162,8 @@ impl Default for AppConfig {
                 constants::GITHUB_ACCOUNT_CREATION_DEADLINE,
             )
             .unwrap(),
-            eth_max_first_transaction_block: constants::ETH_FIRST_TRANSACTION_DEADLINE.to_string(),
+            eth_check_nonce_at_block: constants::ETH_CHECK_NONCE_AT_BLOCK.to_string(),
+            eth_min_nonce: constants::ETH_MIN_NONCE,
             eth_rpc_url: env::var("ETH_RPC_URL").expect("Missing ETH_RPC_URL"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,19 @@ async fn main() {
         .unwrap();
 }
 
-fn siwe_oauth_client() -> SiweAuthClient {
+#[derive(Clone)]
+struct SiweOAuthClient {
+    client: BasicClient,
+}
+
+impl Deref for SiweOAuthClient {
+    type Target = BasicClient;
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+fn siwe_oauth_client() -> SiweOAuthClient {
     let client_id = env::var("SIWE_CLIENT_ID").expect("Missing SIWE_CLIENT_ID!");
     let client_secret = env::var("SIWE_CLIENT_SECRET").expect("Missing SIWE_CLIENT_SECRET!");
 
@@ -88,7 +100,7 @@ fn siwe_oauth_client() -> SiweAuthClient {
     let auth_url = env::var("SIWE_AUTH_URL").unwrap_or_else(|_| SIWE_OAUTH_AUTH_URL.to_string());
     let token_url = env::var("SIWE_TOKEN_URL").unwrap_or_else(|_| SIWE_OAUTH_TOKEN_URL.to_string());
 
-    SiweAuthClient {
+    SiweOAuthClient {
         client: BasicClient::new(
             ClientId::new(client_id),
             Some(ClientSecret::new(client_secret)),
@@ -105,18 +117,6 @@ struct GithubOAuthClient {
 }
 
 impl Deref for GithubOAuthClient {
-    type Target = BasicClient;
-    fn deref(&self) -> &Self::Target {
-        &self.client
-    }
-}
-
-#[derive(Clone)]
-struct SiweAuthClient {
-    client: BasicClient,
-}
-
-impl Deref for SiweAuthClient {
     type Target = BasicClient;
     fn deref(&self) -> &Self::Target {
         &self.client

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,3 @@
-mod api;
-mod constants;
-mod jwt;
-mod keys;
-mod sessions;
-
-use crate::api::v1::auth::github_callback;
-use crate::api::v1::{
-    auth::{auth_client_string, authorised},
-    contribute::contribute,
-    info::{current_state, jwt_info, status},
-    slot::slot_join,
-};
-use crate::constants::{GITHUB_OAUTH_AUTH_URL, GITHUB_OAUTH_REDIRECT_URL, GITHUB_OAUTH_TOKEN_URL};
-use axum::{
-    extract::Extension,
-    response::Html,
-    routing::{get, post},
-    Router,
-};
-use chrono::{DateTime, FixedOffset};
-use constants::{
-    LOBBY_CHECKIN_DEADLINE, LOBBY_FLUSH_INTERVAL, OAUTH_AUTH_URL, OAUTH_REDIRECT_URL,
-    OAUTH_TOKEN_URL,
-};
-use jwt::Receipt;
-use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RedirectUrl, TokenUrl};
-use sessions::{SessionId, SessionInfo};
-use small_powers_of_tau::sdk::Transcript;
 use std::ops::Deref;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -34,7 +5,39 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+
+use axum::{
+    extract::Extension,
+    response::Html,
+    routing::{get, post},
+    Router,
+};
+use chrono::{DateTime, FixedOffset};
+use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RedirectUrl, TokenUrl};
+use small_powers_of_tau::sdk::Transcript;
 use tokio::{sync::RwLock, time::Interval};
+
+use constants::{LOBBY_CHECKIN_DEADLINE, LOBBY_FLUSH_INTERVAL};
+use jwt::Receipt;
+use sessions::{SessionId, SessionInfo};
+
+use crate::api::v1::auth::{github_callback, siwe_callback};
+use crate::api::v1::{
+    auth::auth_client_string,
+    contribute::contribute,
+    info::{current_state, jwt_info, status},
+    slot::slot_join,
+};
+use crate::constants::{
+    GITHUB_OAUTH_AUTH_URL, GITHUB_OAUTH_REDIRECT_URL, GITHUB_OAUTH_TOKEN_URL, SIWE_OAUTH_AUTH_URL,
+    SIWE_OAUTH_REDIRECT_URL, SIWE_OAUTH_TOKEN_URL,
+};
+
+mod api;
+mod constants;
+mod jwt;
+mod keys;
+mod sessions;
 
 pub type SharedTranscript = Arc<RwLock<Transcript>>;
 pub(crate) type SharedState = Arc<RwLock<AppState>>;
@@ -51,21 +54,20 @@ async fn main() {
     let interval = tokio::time::interval(Duration::from_secs(LOBBY_FLUSH_INTERVAL as u64));
     tokio::spawn(clear_lobby_on_interval(shared_state_clone, interval));
 
-    let oauth_client = oauth_client();
-
     let app = Router::new()
         .route("/hello_world", get(hello_world))
         .route("/auth/request_link", get(auth_client_string))
         .route("/auth/callback/github", get(github_callback))
-        .route("/auth/authorized", get(authorised))
+        .route("/auth/callback/siwe", get(siwe_callback))
         .route("/slot/join", post(slot_join))
         .route("/contribute", post(contribute))
         .route("/info/status", get(status))
         .route("/info/jwt", get(jwt_info))
         .route("/info/current_state", get(current_state))
         .layer(Extension(shared_state))
-        .layer(Extension(oauth_client))
+        .layer(Extension(siwe_oauth_client()))
         .layer(Extension(github_oauth_client()))
+        .layer(Extension(reqwest::Client::new()))
         .layer(Extension(AppConfig::default()))
         .layer(Extension(transcript));
 
@@ -77,21 +79,24 @@ async fn main() {
         .unwrap();
 }
 
-fn oauth_client() -> BasicClient {
-    let client_id = env::var("CLIENT_ID").expect("Missing CLIENT_ID!");
-    let client_secret = env::var("CLIENT_SECRET").expect("Missing CLIENT_SECRET!");
+fn siwe_oauth_client() -> SiweAuthClient {
+    let client_id = env::var("SIWE_CLIENT_ID").expect("Missing SIWE_CLIENT_ID!");
+    let client_secret = env::var("SIWE_CLIENT_SECRET").expect("Missing SIWE_CLIENT_SECRET!");
 
-    let redirect_url = env::var("REDIRECT_URL").unwrap_or_else(|_| OAUTH_REDIRECT_URL.to_string());
-    let auth_url = env::var("AUTH_URL").unwrap_or_else(|_| OAUTH_AUTH_URL.to_string());
-    let token_url = env::var("TOKEN_URL").unwrap_or_else(|_| OAUTH_TOKEN_URL.to_string());
+    let redirect_url =
+        env::var("SIWE_REDIRECT_URL").unwrap_or_else(|_| SIWE_OAUTH_REDIRECT_URL.to_string());
+    let auth_url = env::var("SIWE_AUTH_URL").unwrap_or_else(|_| SIWE_OAUTH_AUTH_URL.to_string());
+    let token_url = env::var("SIWE_TOKEN_URL").unwrap_or_else(|_| SIWE_OAUTH_TOKEN_URL.to_string());
 
-    BasicClient::new(
-        ClientId::new(client_id),
-        Some(ClientSecret::new(client_secret)),
-        AuthUrl::new(auth_url).unwrap(),
-        Some(TokenUrl::new(token_url).unwrap()),
-    )
-    .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap())
+    SiweAuthClient {
+        client: BasicClient::new(
+            ClientId::new(client_id),
+            Some(ClientSecret::new(client_secret)),
+            AuthUrl::new(auth_url).unwrap(),
+            Some(TokenUrl::new(token_url).unwrap()),
+        )
+        .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap()),
+    }
 }
 
 #[derive(Clone)]
@@ -100,6 +105,18 @@ struct GithubOAuthClient {
 }
 
 impl Deref for GithubOAuthClient {
+    type Target = BasicClient;
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+#[derive(Clone)]
+struct SiweAuthClient {
+    client: BasicClient,
+}
+
+impl Deref for SiweAuthClient {
     type Target = BasicClient;
     fn deref(&self) -> &Self::Target {
         &self.client
@@ -133,6 +150,8 @@ async fn hello_world() -> Html<&'static str> {
 #[derive(Clone)]
 pub(crate) struct AppConfig {
     github_max_creation_time: DateTime<FixedOffset>,
+    eth_max_first_transaction_block: String,
+    eth_rpc_url: String,
 }
 
 impl Default for AppConfig {
@@ -142,6 +161,8 @@ impl Default for AppConfig {
                 constants::GITHUB_ACCOUNT_CREATION_DEADLINE,
             )
             .unwrap(),
+            eth_max_first_transaction_block: constants::ETH_FIRST_TRANSACTION_DEADLINE.to_string(),
+            eth_rpc_url: env::var("ETH_RPC_URL").expect("Missing ETH_RPC_URL"),
         }
     }
 }
@@ -294,6 +315,6 @@ async fn flush_on_predicate() {
     for id in session_ids {
         let info = state.lobby.get(&id).unwrap();
         // We should just be left with `exp` numbers which are odd
-        assert!(info.token.exp % 2 == 1)
+        assert_eq!(info.token.exp % 2, 1)
     }
 }


### PR DESCRIPTION
This includes a number of changes to the auth flow:
1. Removed the use of Auth0 altogether: we're not using their unified profiles anyway, as we need custom per-provider verifications. On top of that, it imposed artificial rate limits, which could bite us in the future. We now use vanilla github login & vanilla deployment of SIWE (the one that Auth0 used anyway, just without the indirection).
2. Verifying that a github user was created before a certain date. We could check for commits, but that's more involved and I don't think the return is that big.
3. Verifying that an ETH address made at least one transaction before a certain block.

If you need the dev secret keys, let me know on Telegram, I can share. I'm using Alchemy for RPC, so for deploy we'll probably need a better key anyway.