### PR TITLE
Fix sql and default value of keys

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -15,11 +15,11 @@ pub static KEYS: OnceCell<Keys> = OnceCell::new();
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 pub struct Options {
     /// Public key file (.pem) to use for JWT verification
-    #[clap(long, env, default_value = "private.key")]
+    #[clap(long, env, default_value = "publickey.pem")]
     pub public_key: PathBuf,
 
     /// Private key file (.key) to use for JWT verification
-    #[clap(long, env, default_value = "publickey.pem")]
+    #[clap(long, env, default_value = "private.key")]
     pub private_key: PathBuf,
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -29,7 +29,7 @@ pub struct PersistentStorage(Pool<Sqlite>);
 
 impl PersistentStorage {
     pub async fn has_contributed(&self, uid: &str) -> Result<bool, StorageError> {
-        let sql = "SELECT EXISTS(SELECT 1 FROM contributors WHERE uid = ?1";
+        let sql = "SELECT EXISTS(SELECT 1 FROM contributors WHERE uid = ?1)";
         self.0
             .fetch_one(sqlx::query(sql).bind(uid))
             .await


### PR DESCRIPTION
Found two typos while I was trying to run the sequencer in a local environment.
The first one is that the closing parenthesis was missing in PersistentStorage's `has_contributed` function.
The second one is keys' default values were the other way around.