### PR TITLE
validate ceremony sizes

### DIFF
--- a/crypto/criterion.rs
+++ b/crypto/criterion.rs
@@ -1,7 +1,9 @@
 use kzg_ceremony_crypto as lib;
 
 fn main() {
-    let mut criterion = criterion::Criterion::default().configure_from_args().sample_size(10);
+    let mut criterion = criterion::Criterion::default()
+        .configure_from_args()
+        .sample_size(10);
     lib::bench::group(&mut criterion);
     criterion.final_summary();
 }

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -10,14 +10,14 @@ pub struct BatchTranscript {
 }
 
 impl BatchTranscript {
-    pub fn new<I>(iter: I) -> Self
+    pub fn new<'a, I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (usize, usize)>,
+        I: IntoIterator<Item = &'a (usize, usize)> + 'a,
     {
         Self {
             transcripts: iter
                 .into_iter()
-                .map(|(num_g1, num_g2)| Transcript::new(num_g1, num_g2))
+                .map(|(num_g1, num_g2)| Transcript::new(*num_g1, *num_g2))
                 .collect(),
         }
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,8 +1,102 @@
 // TODO: Error handling
 
+use crate::SharedTranscript;
+use eyre::eyre;
+use kzg_ceremony_crypto::BatchTranscript;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
+
+/// Represents a size constraint on a batch transcript
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CeremonySizes {
+    sizes: Vec<(usize, usize)>,
+}
+
+impl CeremonySizes {
+    /// Parses a size constraint from command line format. The format accepted
+    /// is a `:`-separated list of `,`-separated pairs denoting the expected
+    /// number of, respectively, G1 and G2 points in consecutive ceremonies.
+    /// For example, `1,2:3,4:5,6` denotes 3 ceremonies, the first containing
+    /// 1 G1 point and 2 G2 points.
+    pub fn parse_from_cmd(cmd: &str) -> eyre::Result<CeremonySizes> {
+        let ceremonies = cmd.split(":");
+        let parsed_ceremonies: Vec<_> = ceremonies
+            .map(|ceremony| {
+                let parts = ceremony.split(",").collect::<Vec<_>>();
+                if parts.len() != 2 {
+                    Err(eyre!("Invalid ceremony sizes description {ceremony}"))
+                } else {
+                    Ok((parts[0].parse()?, parts[1].parse()?))
+                }
+            })
+            .collect::<eyre::Result<_>>()?;
+        if parsed_ceremonies.len() == 0 {
+            return Err(eyre!("Must specify at least one ceremony"));
+        }
+        Ok(CeremonySizes {
+            sizes: parsed_ceremonies,
+        })
+    }
+
+    /// Validates a batch transcript against this shape description
+    ///
+    /// # Errors:
+    /// - when the transcript does not conform to the required shape
+    fn validate_batch_transcript(&self, transcript: &BatchTranscript) -> eyre::Result<()> {
+        let defined_ceremonies = transcript.transcripts.len();
+        let expected_ceremonies = self.sizes.len();
+        if defined_ceremonies != expected_ceremonies {
+            return Err(eyre!(
+                "Wrong number of transcripts in the batch: expected {expected_ceremonies} but got \
+                 {defined_ceremonies}."
+            ));
+        }
+        self.sizes
+            .iter()
+            .enumerate()
+            .zip(transcript.transcripts.iter())
+            .try_for_each(|((i, (expected_num_g1, expected_num_g2)), transcript)| {
+                let actual_num_g1 = &transcript.powers.g1.len();
+                if actual_num_g1 != expected_num_g1 {
+                    return Err(eyre!(
+                        "Wrong number of G1 points in transcript #{i}: expected \
+                         {expected_num_g1}, but got {actual_num_g1}"
+                    ));
+                }
+                let actual_num_g2 = &transcript.powers.g2.len();
+                if actual_num_g2 != expected_num_g2 {
+                    return Err(eyre!(
+                        "Wrong number of G2 points in transcript #{i}: expected \
+                         {expected_num_g2}, but got {actual_num_g2}"
+                    ));
+                }
+                Ok(())
+            })?;
+        Ok(())
+    }
+}
+
+/// Reads a transcript file from disk, or creates it, if it doesn't exist.
+///
+/// # Errors:
+/// - when the transcript exists, but does not conform to the required shape.
+pub async fn read_or_create_transcript(
+    path: PathBuf,
+    work_path: PathBuf,
+    ceremony_sizes: &CeremonySizes,
+) -> eyre::Result<SharedTranscript> {
+    if !path.exists() {
+        let transcript = BatchTranscript::new(&ceremony_sizes.sizes);
+        let shared_transcript = Arc::new(RwLock::new(transcript));
+        write_json_file(path, work_path, shared_transcript.clone()).await;
+        Ok(shared_transcript)
+    } else {
+        let transcript = read_json_file::<BatchTranscript>(path).await;
+        ceremony_sizes.validate_batch_transcript(&transcript)?;
+        Ok(Arc::new(RwLock::new(transcript)))
+    }
+}
 
 /// Asynchronously reads a JSON file from disk.
 pub async fn read_json_file<T: DeserializeOwned + Send + 'static>(path: PathBuf) -> T {


### PR DESCRIPTION
## Motivation
It is important that the system operates with properly set-up ceremony & also that it can start without having to provide an 8MB initial transcript file.

## Solution
This PR adds a cmd/env option allowing to specify ceremony sizes, and initializes an empty transcript on startup, if the file does not exist. If the file exists, it will be validated for size.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
