### PR TITLE
Post sign in redirect to the frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "async-session",
  "axum",
  "axum-extra",
+ "base64 0.13.0",
  "chrono",
  "clap",
  "cli-batteries",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ cli-batteries = { version = "0.3.3", features = ["signals", "prometheus", "meter
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 axum = { version = "0.5.15", features = ["headers"] }
 axum-extra = { version = "0.3.7", features = ["erased-json"] }
+base64 = "0.13"
 hyper = "0.14"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -248,7 +248,7 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let Query(raw): Query<RawAuthPayload> = Query::from_request(req)
             .await
-            .map_err(|err| err.into_response())?;
+            .map_err(IntoResponse::into_response)?;
         let decoded_state =
             base64::decode_config(raw.state, base64::URL_SAFE_NO_PAD).map_err(|_| {
                 (

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -5,7 +5,6 @@ use crate::{
     storage::{PersistentStorage, StorageError},
     EthAuthOptions, Options, SessionId, SessionInfo,
 };
-use async_session::base64;
 use axum::{
     async_trait,
     extract::{FromRequest, Query, RequestParts},


### PR DESCRIPTION

## Motivation
We want to make the app completely frontend-agnostic.

## Solution

The auth-links now always redirect to the backend. The custom url set by the GUI is encoded in the `state` field of oauth flow, allowing us to read it after redirect from the auth provider. We then redirect to the frontend, passing all the normal response fields (session_id, nickname, etc.) as params. Security-wise nothing really changes IMO, but please share any concerns before this lands.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
