### PR TITLE
rename pubkey to pot_pubkey

### DIFF
--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -13,7 +13,7 @@ pub struct BatchContribution {
 impl BatchContribution {
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]
     pub fn receipt(&self) -> Vec<G2> {
-        self.contributions.iter().map(|c| c.pubkey).collect()
+        self.contributions.iter().map(|c| c.pot_pubkey).collect()
     }
 
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -4,18 +4,19 @@ use std::collections::HashMap;
 use tracing::instrument;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Contribution {
     #[serde(flatten)]
     pub powers: Powers,
 
-    pub pubkey: G2,
+    pub pot_pubkey: G2,
 }
 
 impl Contribution {
     /// Check if the contribution has any entropy added.
     #[must_use]
     pub fn has_entropy(&self) -> bool {
-        self.pubkey != G2::one()
+        self.pot_pubkey != G2::one()
     }
 
     /// Adds entropy to this contribution. Can be called multiple times.
@@ -27,14 +28,14 @@ impl Contribution {
         // Validate points
         E::validate_g1(&self.powers.g1)?;
         E::validate_g2(&self.powers.g2)?;
-        E::validate_g2(&[self.pubkey])?;
+        E::validate_g2(&[self.pot_pubkey])?;
 
         // Add entropy
         E::add_entropy_g1(entropy, &mut self.powers.g1)?;
         E::add_entropy_g2(entropy, &mut self.powers.g2)?;
-        let mut temp = [G2::zero(), self.pubkey];
+        let mut temp = [G2::zero(), self.pot_pubkey];
         E::add_entropy_g2(entropy, &mut temp)?;
-        self.pubkey = temp[1];
+        self.pot_pubkey = temp[1];
 
         Ok(())
     }
@@ -54,7 +55,7 @@ impl Contribution {
         }
 
         // Zero values are never allowed
-        if self.pubkey == G2::zero() {
+        if self.pot_pubkey == G2::zero() {
             return Err(CeremonyError::ZeroPubkey);
         }
         for (i, g1) in self.powers.g1.iter().enumerate() {
@@ -77,7 +78,7 @@ impl Contribution {
         }
 
         // If there is no entropy yet, all values must be one.
-        if self.pubkey == G2::one()
+        if self.pot_pubkey == G2::one()
             && self.powers.g1.iter().all(|g1| *g1 == G1::one())
             && self.powers.g2.iter().all(|g2| *g2 == G2::one())
         {
@@ -103,7 +104,7 @@ impl Contribution {
             if *g2 == G2::one() {
                 return Err(CeremonyError::InvalidG2One(i));
             }
-            if i > 1 && *g2 == self.pubkey {
+            if i > 1 && *g2 == self.pot_pubkey {
                 return Err(CeremonyError::InvalidG2Pubkey(i));
             }
             if let Some(j) = set.get(g2) {
@@ -123,8 +124,8 @@ mod test {
     #[test]
     fn contribution_json() {
         let value = Contribution {
-            powers: Powers::new(2, 4),
-            pubkey: G2::one(),
+            powers:     Powers::new(2, 4),
+            pot_pubkey: G2::one(),
         };
         let json = serde_json::to_value(&value).unwrap();
         assert_eq!(
@@ -144,7 +145,7 @@ mod test {
                 "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
                 ]
             },
-            "pubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+            "potPubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
             })
         );
         let deser = serde_json::from_value::<Contribution>(json).unwrap();

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -55,8 +55,8 @@ impl Transcript {
     #[must_use]
     pub fn contribution(&self) -> Contribution {
         Contribution {
-            powers: self.powers.clone(),
-            pubkey: G2::one(),
+            powers:     self.powers.clone(),
+            pot_pubkey: G2::one(),
         }
     }
 
@@ -93,13 +93,13 @@ impl Transcript {
         // Verify the contribution points (encoding and subgroup checks).
         E::validate_g1(&contribution.powers.g1)?;
         E::validate_g2(&contribution.powers.g2)?;
-        E::validate_g2(&[contribution.pubkey])?;
+        E::validate_g2(&[contribution.pot_pubkey])?;
 
         // Verify pairings.
         E::verify_pubkey(
             contribution.powers.g1[1],
             self.powers.g1[1],
-            contribution.pubkey,
+            contribution.pot_pubkey,
         )?;
         E::verify_g1(&contribution.powers.g1, contribution.powers.g2[1])?;
         E::verify_g2(
@@ -115,7 +115,7 @@ impl Transcript {
     /// verified.
     pub fn add(&mut self, contribution: Contribution) {
         self.witness.products.push(contribution.powers.g1[1]);
-        self.witness.pubkeys.push(contribution.pubkey);
+        self.witness.pubkeys.push(contribution.pot_pubkey);
         self.powers = contribution.powers;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ mod tests {
 
     pub fn invalid_contribution(transcript: &BatchTranscript, no: u8) -> BatchContribution {
         let mut contribution = valid_contribution(transcript, no);
-        contribution.contributions[0].pubkey = G2::zero();
+        contribution.contributions[0].pot_pubkey = G2::zero();
         contribution
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -244,7 +244,7 @@ async fn contribute_successfully(
         contribution
             .contributions
             .iter()
-            .map(|c| c.pubkey)
+            .map(|c| c.pot_pubkey)
             .collect::<Vec<_>>()
     )
 }
@@ -256,7 +256,7 @@ fn assert_includes_contribution(transcript: &BatchTranscript, contribution: &Bat
         .zip(contribution.contributions.iter())
         .for_each(|(t, c)| {
             assert!(t.witness.products.contains(&c.powers.g1[0]));
-            assert!(t.witness.pubkeys.contains(&c.pubkey));
+            assert!(t.witness.pubkeys.contains(&c.pot_pubkey));
         })
 }
 
@@ -318,7 +318,7 @@ async fn test_contribution_happy_path() {
     let contrib_pubkeys = contribution
         .contributions
         .iter()
-        .map(|contribution| contribution.pubkey)
+        .map(|contribution| contribution.pot_pubkey)
         .collect::<Vec<_>>();
     let transcript_pubkeys = transcript
         .transcripts


### PR DESCRIPTION
Rename `pubkey` to `potPubkey` according to the [spec](https://github.com/ethereum/kzg-ceremony-specs/blob/cbc1f4d8d6a4f2fd5582bdabc34d8dd92e633397/apiSpec/contributionSchema.json#L63).