### PR TITLE
Zeroize entropy after a contribution is made and switched to ChaCha20Rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "hex-literal",
  "proptest",
  "rand",
+ "rand_chacha",
  "rayon",
  "ruint",
  "serde",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.34"
 tracing = "0.1.36"
 zeroize = "1.5.7"
 hex-literal = "0.3.4"
+rand_chacha = "0.3.1"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -172,7 +172,6 @@ fn random_factors(n: usize) -> (Vec<<Fr as PrimeField>::BigInt>, Fr) {
 }
 
 fn random_scalar(entropy: [u8; 32]) -> Fr {
-    // TODO: Use an explicit cryptographic rng.
     let mut rng = ChaCha20Rng::from_seed(entropy);
     Fr::rand(&mut rng)
 }

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -13,7 +13,8 @@ use ark_ec::{
     msm::VariableBaseMSM, wnaf::WnafContext, AffineCurve, PairingEngine, ProjectiveCurve,
 };
 use ark_ff::{One, PrimeField, UniformRand, Zero};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
 use std::iter;
 use tracing::instrument;
@@ -172,7 +173,7 @@ fn random_factors(n: usize) -> (Vec<<Fr as PrimeField>::BigInt>, Fr) {
 
 fn random_scalar(entropy: [u8; 32]) -> Fr {
     // TODO: Use an explicit cryptographic rng.
-    let mut rng = StdRng::from_seed(entropy);
+    let mut rng = ChaCha20Rng::from_seed(entropy);
     Fr::rand(&mut rng)
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -486,10 +486,9 @@ async fn test_large_lobby() {
             tokio::spawn(async move {
                 well_behaved_participant(h.as_ref(), c.as_ref(), format!("user {i}")).await
             })
-        })
-        .collect::<Vec<_>>();
+        });
 
-    let contributions: Vec<_> = futures::future::join_all(handles.into_iter())
+    let contributions: Vec<_> = futures::future::join_all(handles)
         .await
         .into_iter()
         .map(|r| r.expect("must terminate successfully"))
@@ -520,10 +519,9 @@ async fn test_large_lobby_with_misbehaving_users() {
                     None
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        });
 
-    let contributions: Vec<_> = futures::future::join_all(handles.into_iter())
+    let contributions: Vec<_> = futures::future::join_all(handles)
         .await
         .into_iter()
         .map(|r| r.expect("must terminate successfully"))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: <https://github.com/ethereum/kzg-ceremony-sequencer/blob/master/CONTRIBUTING.md>

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Need to make sure that the entropy is dropped after each contribution is made in the batch_contribution and use a more secure rng.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* Zeroize the toxic waste after each contribution is made 
* Switch from `StdRng` to `Chacha20Rng`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
