### PR TITLE
Remove random CSRF tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ pub async fn start_server(
     ));
 
     let app = Router::new()
-        .layer(TraceLayer::new_for_http())
         .route("/hello_world", get(hello_world))
         .route("/auth/request_link", get(auth_client_link))
         .route("/auth/callback/github", get(github_callback))
@@ -151,7 +150,8 @@ pub async fn start_server(
         .layer(Extension(reqwest::Client::new()))
         .layer(Extension(storage_client(&options.storage).await?))
         .layer(Extension(transcript))
-        .layer(Extension(options.clone()));
+        .layer(Extension(options.clone()))
+        .layer(TraceLayer::new_for_http());
 
     // Run the server
     let (addr, prefix) = parse_url(&options.server)?;

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -2,10 +2,7 @@ mod ethereum;
 mod github;
 
 use crate::sessions::SessionId;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;
 
 pub use self::{
@@ -15,13 +12,9 @@ pub use self::{
 
 pub type SharedAuthState = Arc<RwLock<AuthState>>;
 pub type IdTokenSub = String;
-pub type CsrfToken = String;
 
 #[derive(Default)]
 pub struct AuthState {
-    // CSRF tokens for oAUTH
-    pub csrf_tokens: BTreeSet<CsrfToken>,
-
     // A map between a users unique social id
     // and their session.
     // We use this to check if a user has already entered the lobby


### PR DESCRIPTION
## Motivation
The CSRF token system, as it exists right now, does not serve any purpose: one can generate a token by just hitting an endpoint (not origin-controlled itself). On top of that, there is no such notion as "CSRF attack" from the perspective of the backend: any frontend is equally welcome. Moreover, the system, as it exists adds bloat: we store a map of these in memory, which opens us up to spam attacks.

## Solution
Remove the system.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
