### PR TITLE
remove unoptimized subgroup check

### DIFF
--- a/crypto/src/engine/arkworks/zcash_format.rs
+++ b/crypto/src/engine/arkworks/zcash_format.rs
@@ -190,6 +190,12 @@ pub fn parse_g<P: SWModelParameters, const N: usize>(
         GroupAffine::<P>::get_point_from_x(x, greatest).ok_or(ParseError::InvalidXCoordinate)?;
     debug_assert!(point.is_on_curve()); // Always true
 
+    // Subgroup check is expensive and therefore not done as part of parsing.
+    // TODO: A safer API to indicate whether the check is required.
+    // if !point.is_in_correct_subgroup_assuming_on_curve() {
+    //     return Err(ParseError::InvalidSubgroup);
+    // }
+
     Ok(point)
 }
 

--- a/crypto/src/engine/arkworks/zcash_format.rs
+++ b/crypto/src/engine/arkworks/zcash_format.rs
@@ -189,9 +189,6 @@ pub fn parse_g<P: SWModelParameters, const N: usize>(
     let point =
         GroupAffine::<P>::get_point_from_x(x, greatest).ok_or(ParseError::InvalidXCoordinate)?;
     debug_assert!(point.is_on_curve()); // Always true
-    if !point.is_in_correct_subgroup_assuming_on_curve() {
-        return Err(ParseError::InvalidSubgroup);
-    }
 
     Ok(point)
 }


### PR DESCRIPTION
The unoptimized subgroup check is still used when parsing. 