### PR TITLE
Consolidate locks on lobby and active contributor

### DIFF
--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -1,7 +1,7 @@
 use crate::{
     io::write_json_file,
     keys::{SharedKeys, Signature, SignatureError},
-    lobby::{SharedContributorState, SharedLobbyState},
+    lobby::SharedLobbyState,
     receipt::Receipt,
     storage::{PersistentStorage, StorageError},
     Engine, Options, SessionId, SharedCeremonyStatus, SharedTranscript,
@@ -65,7 +65,6 @@ impl IntoResponse for ContributeError {
 pub async fn contribute(
     session_id: SessionId,
     Json(contribution): Json<BatchContribution>,
-    Extension(contributor_state): Extension<SharedContributorState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(options): Extension<Options>,
     Extension(shared_transcript): Extension<SharedTranscript>,
@@ -73,25 +72,21 @@ pub async fn contribute(
     Extension(num_contributions): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> Result<ContributeReceipt, ContributeError> {
-    contributor_state
+    let id_token = lobby_state
         .begin_contributing(&session_id)
         .await
-        .map_err(|_| ContributeError::NotUsersTurn)?;
+        .map_err(|_| ContributeError::NotUsersTurn)?
+        .token;
 
-    let id_token = {
-        let mut lobby = lobby_state.write().await;
-        lobby.participants.remove(&session_id).unwrap().token
-    };
-
-    // 2. Check if the program state transition was correct
     let result = {
         let mut transcript = shared_transcript.write().await;
         transcript
             .verify_add::<Engine>(contribution.clone())
             .map_err(ContributeError::InvalidContribution)
     };
+
     if let Err(e) = result {
-        contributor_state.clear().await;
+        lobby_state.clear_current_contributor().await;
         storage
             .expire_contribution(id_token.unique_identifier())
             .await?;
@@ -115,7 +110,7 @@ pub async fn contribute(
     )
     .await;
 
-    contributor_state.clear().await;
+    lobby_state.clear_current_contributor().await;
     storage.finish_contribution(&session_id.0).await?;
 
     num_contributions.fetch_add(1, Ordering::Relaxed);
@@ -128,20 +123,14 @@ pub async fn contribute(
 
 pub async fn contribute_abort(
     session_id: SessionId,
-    Extension(contributor_state): Extension<SharedContributorState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
 ) -> Result<(), ContributeError> {
-    contributor_state
-        .abort(&session_id)
+    lobby_state
+        .abort_contribution(&session_id)
         .await
         .map_err(|_| ContributeError::NotUsersTurn)?;
-
-    let mut lobby = lobby_state.write().await;
-    lobby.participants.remove(&session_id);
-
     storage.expire_contribution(&session_id.0).await?;
-
     Ok(())
 }
 
@@ -157,7 +146,7 @@ mod tests {
         io::read_json_file,
         keys,
         keys::SharedKeys,
-        lobby::SharedContributorState,
+        lobby::SharedLobbyState,
         storage::storage_client,
         test_util::{create_test_session_info, test_options},
         tests::{invalid_contribution, test_transcript, valid_contribution},
@@ -181,14 +170,12 @@ mod tests {
     async fn rejects_out_of_turn_contribution() {
         let opts = test_options();
         let db = storage_client(&opts.storage).await.unwrap();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let transcript = test_transcript();
         let contrbution = valid_contribution(&transcript, 1);
         let result = contribute(
             SessionId::new(),
             Json(contrbution),
-            Extension(contributor_state),
             Extension(lobby_state),
             Extension(opts),
             Extension(Arc::new(RwLock::new(transcript))),
@@ -204,16 +191,12 @@ mod tests {
     async fn rejects_invalid_contribution() {
         let opts = test_options();
         let db = storage_client(&opts.storage).await.unwrap();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let participant = SessionId::new();
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+        lobby_state
             .set_current_contributor(&participant, opts.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
@@ -222,7 +205,6 @@ mod tests {
         let result = contribute(
             participant,
             Json(contribution),
-            Extension(contributor_state),
             Extension(lobby_state),
             Extension(opts),
             Extension(Arc::new(RwLock::new(transcript))),
@@ -240,7 +222,6 @@ mod tests {
     #[tokio::test]
     async fn accepts_valid_contribution() {
         let keys = shared_keys();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let participant = SessionId::new();
         let cfg = test_options();
@@ -264,20 +245,17 @@ mod tests {
         };
         let shared_transcript = Arc::new(RwLock::new(transcript));
 
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+
+        lobby_state
             .set_current_contributor(&participant, cfg.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
         let result = contribute(
             participant.clone(),
             Json(contribution_1),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(cfg.clone()),
             Extension(shared_transcript.clone()),
@@ -290,20 +268,17 @@ mod tests {
         assert!(matches!(result, Ok(_)));
         let transcript = read_json_file::<BatchTranscript>(cfg.transcript_file.clone()).await;
         assert_eq!(transcript, transcript_1);
-        {
-            let mut lobby = lobby_state.write().await;
-            lobby
-                .participants
-                .insert(participant.clone(), create_test_session_info(100));
-        }
-        contributor_state
+        lobby_state
+            .insert_participant(participant.clone(), create_test_session_info(100))
+            .await;
+
+        lobby_state
             .set_current_contributor(&participant, cfg.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
         let result = contribute(
             participant.clone(),
             Json(contribution_2),
-            Extension(contributor_state.clone()),
             Extension(lobby_state),
             Extension(cfg.clone()),
             Extension(shared_transcript.clone()),
@@ -321,7 +296,6 @@ mod tests {
     #[tokio::test]
     async fn aborts_contribution() {
         let opts = test_options();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let transcript = Arc::new(RwLock::new(test_transcript()));
         let db = storage_client(&opts.storage).await.unwrap();
@@ -329,25 +303,20 @@ mod tests {
         let session_id = SessionId::new();
         let other_session_id = SessionId::new();
 
-        // add two participants to lobby
-        {
-            let mut state = lobby_state.write().await;
-            state
-                .participants
-                .insert(session_id.clone(), create_test_session_info(100));
-            state
-                .participants
-                .insert(other_session_id.clone(), create_test_session_info(100));
-        }
+        lobby_state
+            .insert_participant(session_id.clone(), create_test_session_info(100))
+            .await;
+        lobby_state
+            .insert_participant(other_session_id.clone(), create_test_session_info(100))
+            .await;
 
-        contributor_state
+        lobby_state
             .set_current_contributor(&session_id, opts.lobby.compute_deadline, db.clone())
             .await
             .unwrap();
 
         let contribution_in_progress_response = try_contribute(
             other_session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -362,7 +331,6 @@ mod tests {
 
         contribute_abort(
             session_id,
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
         )
@@ -374,7 +342,6 @@ mod tests {
 
         let success_response = try_contribute(
             other_session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),

--- a/src/api/v1/info.rs
+++ b/src/api/v1/info.rs
@@ -33,10 +33,7 @@ pub async fn status(
     Extension(ceremony_status): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> StatusResponse {
-    let lobby_size = {
-        let state = lobby_state.read().await;
-        state.participants.len()
-    };
+    let lobby_size = lobby_state.get_lobby_size().await;
 
     let num_contributions = ceremony_status.load(Ordering::Relaxed);
     let sequencer_address = keys.address();

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -29,13 +29,9 @@ pub enum TryContributeError {
 impl From<ActiveContributorError> for TryContributeError {
     fn from(err: ActiveContributorError) -> Self {
         match err {
-            ActiveContributorError::AnotherContributionInProgress => {
-                TryContributeError::AnotherContributionInProgress
-            }
-            ActiveContributorError::UserNotInLobby => TryContributeError::UnknownSessionId,
-            ActiveContributorError::NotUsersTurn => {
-                TryContributeError::AnotherContributionInProgress
-            }
+            ActiveContributorError::AnotherContributionInProgress
+            | ActiveContributorError::NotUsersTurn => Self::AnotherContributionInProgress,
+            ActiveContributorError::UserNotInLobby => Self::UnknownSessionId,
         }
     }
 }

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -1,5 +1,5 @@
 use crate::{
-    lobby::{SharedContributorState, SharedLobbyState},
+    lobby::{ActiveContributorError, SharedLobbyState},
     storage::{PersistentStorage, StorageError},
     SessionId, SharedTranscript,
 };
@@ -24,6 +24,20 @@ pub enum TryContributeError {
     AnotherContributionInProgress,
     #[error("error in storage layer: {0}")]
     StorageError(#[from] StorageError),
+}
+
+impl From<ActiveContributorError> for TryContributeError {
+    fn from(err: ActiveContributorError) -> Self {
+        match err {
+            ActiveContributorError::AnotherContributionInProgress => {
+                TryContributeError::AnotherContributionInProgress
+            }
+            ActiveContributorError::UserNotInLobby => TryContributeError::UnknownSessionId,
+            ActiveContributorError::NotUsersTurn => {
+                TryContributeError::AnotherContributionInProgress
+            }
+        }
+    }
 }
 
 impl IntoResponse for TryContributeError {
@@ -69,50 +83,37 @@ impl<C: Serialize> IntoResponse for TryContributeResponse<C> {
 
 pub async fn try_contribute(
     session_id: SessionId,
-    Extension(contributor_state): Extension<SharedContributorState>,
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
     Extension(transcript): Extension<SharedTranscript>,
     Extension(options): Extension<crate::Options>,
 ) -> Result<TryContributeResponse<BatchContribution>, TryContributeError> {
-    let uid: String;
+    let uid = lobby_state
+        .modify_participant(&session_id, |mut info| {
+            let now = Instant::now();
+            let min_diff =
+                options.lobby.lobby_checkin_frequency - options.lobby.lobby_checkin_tolerance;
+            if !info.is_first_ping_attempt && now < info.last_ping_time + min_diff {
+                return Err(TryContributeError::RateLimited);
+            }
+            info.is_first_ping_attempt = false;
+            info.last_ping_time = now;
+            Ok(info.token.unique_identifier().to_owned())
+        })
+        .await
+        .unwrap_or(Err(TryContributeError::UnknownSessionId))?;
 
-    // 1. Check if this is a valid session. If so, we log the ping time
-    {
-        let mut lobby = lobby_state.write().await;
-        let info = lobby
-            .participants
-            .get_mut(&session_id)
-            .ok_or(TryContributeError::UnknownSessionId)?;
-
-        let min_diff =
-            options.lobby.lobby_checkin_frequency - options.lobby.lobby_checkin_tolerance;
-
-        let now = Instant::now();
-        if !info.is_first_ping_attempt && now < info.last_ping_time + min_diff {
-            return Err(TryContributeError::RateLimited);
-        }
-
-        info.is_first_ping_attempt = false;
-        info.last_ping_time = now;
-
-        uid = info.token.unique_identifier().to_owned();
-    }
-
-    match contributor_state
+    lobby_state
         .set_current_contributor(&session_id, options.lobby.compute_deadline, storage.clone())
         .await
-    {
-        Ok(_) => {
-            storage.insert_contributor(&uid).await?;
-            let transcript = transcript.read().await;
+        .map_err(TryContributeError::from)?;
 
-            Ok(TryContributeResponse {
-                contribution: transcript.contribution(),
-            })
-        }
-        Err(_) => Err(TryContributeError::AnotherContributionInProgress),
-    }
+    storage.insert_contributor(&uid).await?;
+    let transcript = transcript.read().await;
+
+    Ok(TryContributeResponse {
+        contribution: transcript.contribution(),
+    })
 }
 
 #[cfg(test)]
@@ -131,7 +132,6 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     async fn lobby_try_contribute_test() {
         let opts = test_options();
-        let contributor_state = SharedContributorState::default();
         let lobby_state = SharedLobbyState::default();
         let transcript = Arc::new(RwLock::new(test_transcript()));
         let db = storage_client(&opts.storage).await.unwrap();
@@ -142,7 +142,6 @@ mod tests {
         // no users in lobby
         let unknown_session_response = try_contribute(
             session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -153,22 +152,16 @@ mod tests {
             unknown_session_response,
             Err(TryContributeError::UnknownSessionId)
         ));
-
-        // add two participants to lobby
-        {
-            let mut state = lobby_state.write().await;
-            state
-                .participants
-                .insert(session_id.clone(), create_test_session_info(100));
-            state
-                .participants
-                .insert(other_session_id.clone(), create_test_session_info(100));
-        }
+        lobby_state
+            .insert_participant(session_id.clone(), create_test_session_info(100))
+            .await;
+        lobby_state
+            .insert_participant(other_session_id.clone(), create_test_session_info(100))
+            .await;
 
         // "other participant" is contributing
         try_contribute(
             other_session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -178,7 +171,6 @@ mod tests {
         .unwrap();
         let contribution_in_progress_response = try_contribute(
             session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -197,7 +189,6 @@ mod tests {
         tokio::time::advance(Duration::from_secs(5)).await;
         let too_soon_response = try_contribute(
             session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -212,13 +203,12 @@ mod tests {
         );
 
         // "other participant" finished contributing
-        contributor_state.clear().await;
+        lobby_state.clear_current_contributor().await;
 
         // call the endpoint too soon - rate limited, no one computing
         tokio::time::advance(Duration::from_secs(5)).await;
         let too_soon_response = try_contribute(
             session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),
@@ -234,7 +224,6 @@ mod tests {
         tokio::time::advance(Duration::from_secs(19)).await;
         let success_response = try_contribute(
             session_id.clone(),
-            Extension(contributor_state.clone()),
             Extension(lobby_state.clone()),
             Extension(db.clone()),
             Extension(transcript.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     io::{read_or_create_transcript, CeremonySizes},
     keys::Keys,
-    lobby::{clear_lobby_on_interval, SharedContributorState, SharedLobbyState},
+    lobby::{clear_lobby_on_interval, SharedLobbyState},
     oauth::{
         eth_oauth_client, github_oauth_client, EthAuthOptions, GithubAuthOptions, SharedAuthState,
     },
@@ -117,8 +117,6 @@ pub async fn start_server(
     )
     .await?;
 
-    let active_contributor_state = SharedContributorState::default();
-
     // TODO: figure it out from the transcript
     let ceremony_status = Arc::new(AtomicUsize::new(0));
     let lobby_state = SharedLobbyState::default();
@@ -142,7 +140,6 @@ pub async fn start_server(
         .route("/info/status", get(status))
         .route("/info/current_state", get(current_state))
         .layer(CorsLayer::permissive())
-        .layer(Extension(active_contributor_state))
         .layer(Extension(lobby_state))
         .layer(Extension(auth_state))
         .layer(Extension(ceremony_status))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub type SharedTranscript = Arc<RwLock<BatchTranscript>>;
 pub type SharedCeremonyStatus = Arc<AtomicUsize>;
 
 pub const DEFAULT_CEREMONY_SIZES: &str = "4096,65:8192,65:16384,65:32768,65";
-pub const MAX_CONTRIBUTION_SIZE: usize = 10485760; // 10MB
+pub const MAX_CONTRIBUTION_SIZE: usize = 10_485_760; // 10MB
 
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 pub struct Options {

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -195,7 +195,7 @@ impl SharedLobbyState {
 
         let mut state = inner.lock().await;
 
-        if matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if &x.id == &participant)
+        if matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if x.id == participant)
         {
             state.active_contributor = ActiveContributor::None;
 

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -3,12 +3,11 @@ use crate::{
     storage::PersistentStorage,
 };
 use clap::Parser;
-use std::{collections::BTreeMap, num::ParseIntError, str::FromStr, sync::Arc, time::Duration};
-use thiserror::Error;
-use tokio::{
-    sync::{Mutex, RwLock},
-    time::Instant,
+use std::{
+    collections::BTreeMap, mem, num::ParseIntError, str::FromStr, sync::Arc, time::Duration,
 };
+use thiserror::Error;
+use tokio::{sync::Mutex, time::Instant};
 
 fn duration_from_str(value: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_secs(u64::from_str(value)?))
@@ -34,13 +33,20 @@ pub struct Options {
 
 #[derive(Default)]
 pub struct LobbyState {
-    pub participants: BTreeMap<SessionId, SessionInfo>,
+    pub participants:       BTreeMap<SessionId, SessionInfo>,
+    pub active_contributor: ActiveContributor,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionInfoWithId {
+    id:   SessionId,
+    info: SessionInfo,
 }
 
 pub enum ActiveContributor {
     None,
-    AwaitingContribution(SessionId),
-    Contributing(SessionId),
+    AwaitingContribution(SessionInfoWithId),
+    Contributing(SessionInfoWithId),
 }
 
 impl Default for ActiveContributor {
@@ -55,14 +61,16 @@ pub enum ActiveContributorError {
     AnotherContributionInProgress,
     #[error("not user's turn")]
     NotUsersTurn,
+    #[error("user not in the lobby")]
+    UserNotInLobby,
 }
 
 #[derive(Clone, Default)]
-pub struct SharedContributorState {
-    inner: Arc<Mutex<ActiveContributor>>,
+pub struct SharedLobbyState {
+    inner: Arc<Mutex<LobbyState>>,
 }
 
-impl SharedContributorState {
+impl SharedLobbyState {
     pub async fn set_current_contributor(
         &self,
         participant: &SessionId,
@@ -70,8 +78,17 @@ impl SharedContributorState {
         storage: PersistentStorage,
     ) -> Result<(), ActiveContributorError> {
         let mut state = self.inner.lock().await;
-        if matches!(*state, ActiveContributor::None) {
-            *state = ActiveContributor::AwaitingContribution(participant.clone());
+
+        if matches!(state.active_contributor, ActiveContributor::None) {
+            let session_info = state
+                .participants
+                .remove(participant)
+                .ok_or(ActiveContributorError::UserNotInLobby)?;
+
+            state.active_contributor = ActiveContributor::AwaitingContribution(SessionInfoWithId {
+                id:   participant.clone(),
+                info: session_info,
+            });
 
             let inner = self.inner.clone();
             let participant = participant.clone();
@@ -92,37 +109,104 @@ impl SharedContributorState {
     pub async fn begin_contributing(
         &self,
         participant: &SessionId,
+    ) -> Result<SessionInfo, ActiveContributorError> {
+        let mut state = self.inner.lock().await;
+
+        match mem::replace(&mut state.active_contributor, ActiveContributor::None) {
+            ActiveContributor::AwaitingContribution(info) if &info.id == participant => {
+                state.active_contributor = ActiveContributor::Contributing(info.clone());
+                Ok(info.info)
+            }
+            other => {
+                state.active_contributor = other;
+                Err(ActiveContributorError::NotUsersTurn)
+            }
+        }
+    }
+
+    pub async fn abort_contribution(
+        &self,
+        participant: &SessionId,
     ) -> Result<(), ActiveContributorError> {
         let mut state = self.inner.lock().await;
 
-        if !matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == participant) {
+        if !matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if &x.id == participant)
+        {
             return Err(ActiveContributorError::NotUsersTurn);
         }
 
-        *state = ActiveContributor::Contributing(participant.clone());
+        state.active_contributor = ActiveContributor::None;
 
         Ok(())
     }
 
-    pub async fn abort(&self, participant: &SessionId) -> Result<(), ActiveContributorError> {
+    pub async fn clear_current_contributor(&self) {
         let mut state = self.inner.lock().await;
-
-        if !matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == participant) {
-            return Err(ActiveContributorError::NotUsersTurn);
-        }
-
-        *state = ActiveContributor::None;
-
-        Ok(())
+        state.active_contributor = ActiveContributor::None;
     }
 
-    pub async fn clear(&self) {
-        let mut state = self.inner.lock().await;
-        *state = ActiveContributor::None;
+    pub async fn clear_lobby(&self, predicate: impl Fn(&SessionInfo) -> bool + Send) {
+        let mut lobby_state = self.inner.lock().await;
+
+        // Iterate top `MAX_LOBBY_SIZE` participants and check if they have
+        let participants = lobby_state.participants.keys().cloned();
+        let mut sessions_to_kick = Vec::new();
+
+        for participant in participants {
+            // Check if they are over their ping deadline
+            lobby_state.participants.get(&participant).map_or_else(
+                ||
+                    // This should not be possible
+                    tracing::debug!("session id in queue but not a valid session"),
+                |session_info| {
+                    if predicate(session_info) {
+                        sessions_to_kick.push(participant);
+                    }
+                },
+            );
+        }
+        for session_id in sessions_to_kick {
+            lobby_state.participants.remove(&session_id);
+        }
+    }
+
+    pub async fn modify_participant<R>(
+        &self,
+        session_id: &SessionId,
+        fun: impl FnOnce(&mut SessionInfo) -> R,
+    ) -> Option<R> {
+        let mut lobby_state = self.inner.lock().await;
+        lobby_state.participants.get_mut(session_id).map(fun)
+    }
+
+    pub async fn get_lobby_size(&self) -> usize {
+        self.inner.lock().await.participants.len()
+    }
+
+    pub async fn insert_participant(&self, session_id: SessionId, session_info: SessionInfo) {
+        self.inner
+            .lock()
+            .await
+            .participants
+            .insert(session_id, session_info);
+    }
+
+    #[cfg(test)]
+    pub async fn get_all_participants(&self) -> Vec<SessionInfoWithId> {
+        self.inner
+            .lock()
+            .await
+            .participants
+            .iter()
+            .map(|(id, info)| SessionInfoWithId {
+                id:   id.clone(),
+                info: info.clone(),
+            })
+            .collect()
     }
 
     async fn expire_current_contributor(
-        inner: Arc<Mutex<ActiveContributor>>,
+        inner: Arc<Mutex<LobbyState>>,
         participant: SessionId,
         compute_deadline: Duration,
         storage: PersistentStorage,
@@ -131,16 +215,15 @@ impl SharedContributorState {
 
         let mut state = inner.lock().await;
 
-        if matches!(&*state, ActiveContributor::AwaitingContribution(x) if x == &participant) {
-            *state = ActiveContributor::None;
+        if matches!(&state.active_contributor, ActiveContributor::AwaitingContribution(x) if &x.id == &participant)
+        {
+            state.active_contributor = ActiveContributor::None;
 
             drop(state);
             storage.expire_contribution(&participant.0).await.unwrap();
         }
     }
 }
-
-pub type SharedLobbyState = Arc<RwLock<LobbyState>>;
 
 pub async fn clear_lobby_on_interval(state: SharedLobbyState, options: Options) {
     let max_diff = options.lobby_checkin_frequency + options.lobby_checkin_tolerance;
@@ -157,33 +240,7 @@ pub async fn clear_lobby_on_interval(state: SharedLobbyState, options: Options) 
             time_diff > max_diff
         };
 
-        let clone = state.clone();
-        clear_lobby(clone, predicate).await;
-    }
-}
-
-async fn clear_lobby(state: SharedLobbyState, predicate: impl Fn(&SessionInfo) -> bool + Send) {
-    let mut lobby_state = state.write().await;
-
-    // Iterate top `MAX_LOBBY_SIZE` participants and check if they have
-    let participants = lobby_state.participants.keys().cloned();
-    let mut sessions_to_kick = Vec::new();
-
-    for participant in participants {
-        // Check if they are over their ping deadline
-        lobby_state.participants.get(&participant).map_or_else(
-            ||
-                // This should not be possible
-                tracing::debug!("session id in queue but not a valid session"),
-            |session_info| {
-                if predicate(session_info) {
-                    sessions_to_kick.push(participant);
-                }
-            },
-        );
-    }
-    for session_id in sessions_to_kick {
-        lobby_state.participants.remove(&session_id);
+        state.clear_lobby(predicate).await;
     }
 }
 
@@ -206,12 +263,10 @@ async fn flush_on_predicate() {
     let arc_state = SharedLobbyState::default();
 
     {
-        let mut state = arc_state.write().await;
-
         for i in 0..to_add {
             let id = SessionId::new();
             let session_info = create_test_session_info(i as u64);
-            state.participants.insert(id, session_info);
+            arc_state.insert_participant(id, session_info).await;
         }
     }
 
@@ -219,17 +274,15 @@ async fn flush_on_predicate() {
     // expiry which is an even number
     let predicate = |session_info: &SessionInfo| -> bool { session_info.token.exp % 2 == 0 };
 
-    clear_lobby(arc_state.clone(), predicate).await;
+    arc_state.clear_lobby(predicate).await;
 
     // Now we expect that half of the lobby should be
     // kicked
-    let state = arc_state.write().await;
-    assert_eq!(state.participants.len(), to_add / 2);
+    let participants = arc_state.get_all_participants().await;
+    assert_eq!(participants.len(), to_add / 2);
 
-    let session_ids = state.participants.keys().cloned();
-    for id in session_ids {
-        let info = state.participants.get(&id).unwrap();
+    for participant in participants {
         // We should just be left with `exp` numbers which are odd
-        assert_eq!(info.token.exp % 2, 1);
+        assert_eq!(participant.info.token.exp % 2, 1);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review


## Motivation
#75 is an example of a race condition coming from independent access to lobby and active contributor states. 

## Solution
This PR fixes this by
1. Making independent access impossible, now both the lobby and active contributor are controlled by a single lock.
2. Making the offending state unrepresentable – we now remove a user from the lobby when they start contributing, with their state being managed separately.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
