### PR TITLE
enable opentelemetry trace id for better logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d1154e21a04949ed59f865206c1c13e56e1001627a7ed5af06cf450edddca3"
+dependencies = [
+ "axum",
+ "http",
+ "opentelemetry 0.18.0",
+ "tower-http",
+ "tracing",
+ "tracing-opentelemetry 0.18.0",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,7 +803,7 @@ dependencies = [
  "itertools",
  "mimalloc",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.17.0",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -804,7 +818,7 @@ dependencies = [
  "tracing-flame",
  "tracing-futures",
  "tracing-log",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.17.4",
  "tracing-serde",
  "tracing-subscriber",
  "url",
@@ -1151,6 +1165,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -2122,6 +2149,7 @@ dependencies = [
  "async-session",
  "axum",
  "axum-extra",
+ "axum-tracing-opentelemetry",
  "base64 0.13.0",
  "chrono",
  "clap 4.0.12",
@@ -2139,6 +2167,7 @@ dependencies = [
  "kzg-ceremony-crypto",
  "oauth2",
  "once_cell",
+ "opentelemetry 0.18.0",
  "rand",
  "reqwest",
  "secrecy",
@@ -2473,6 +2502,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,7 +2520,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
+ "opentelemetry 0.17.0",
 ]
 
 [[package]]
@@ -2494,7 +2533,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http",
- "opentelemetry",
+ "opentelemetry 0.17.0",
  "prost",
  "thiserror",
  "tokio",
@@ -2508,7 +2547,45 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.17.0",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4215,7 +4292,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.17.0",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.18.0",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ clap = { version = "4.0", features = ["derive"] }
 eyre = "0.6.8"
 url = "2.3.1"
 hex = "0.4.3"
+axum-tracing-opentelemetry = "0.5.0"
+opentelemetry = "0.18.0"
 
 # Use Rustls because it makes it easier to cross-compile on CI
 reqwest = { version = "0.11", default-features = false, features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,8 @@ use std::{
     sync::{atomic::AtomicUsize, Arc},
 };
 use tokio::sync::RwLock;
-use tower_http::{
-    cors::CorsLayer,
-    limit::RequestBodyLimitLayer,
-    trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
-};
-use tracing::{debug, info, Level};
+use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer};
+use tracing::{debug, info};
 use url::Url;
 
 mod api;
@@ -176,11 +172,7 @@ pub async fn start_server(
     let app = Router::new()
         .nest(prefix, app)
         .fallback(handle_404.into_service())
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(DefaultMakeSpan::default().level(Level::INFO))
-                .on_response(DefaultOnResponse::default().level(Level::INFO)),
-        );
+        .layer(axum_tracing_opentelemetry::opentelemetry_tracing_layer());
     let server = Server::try_bind(&addr)?.serve(app.into_make_service());
     Ok(server)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,16 @@
 use cli_batteries::version;
 use kzg_ceremony_sequencer::async_main;
+use opentelemetry::{global, sdk::export::trace::stdout::PipelineBuilder};
 
 #[allow(dead_code)] // Entry point
 fn main() {
+    // Install OpenTelemetry tracer to enable trace ids
+    PipelineBuilder::default()
+        .with_writer(std::io::sink())
+        .install_simple();
+
     cli_batteries::run(version!(crypto, small_powers_of_tau), async_main);
+
+    // For completeness only. Currently we are not exporting otlp spans anyway
+    global::shutdown_tracer_provider();
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 use tokio::time::Instant;
+use tracing::warn;
 use uuid::Uuid;
 
 #[derive(Debug, Hash, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -96,7 +97,10 @@ where
         let TypedHeader(Authorization(bearer)) =
             TypedHeader::<Authorization<Bearer>>::from_request(req)
                 .await
-                .map_err(|_| SessionError::InvalidSessionId)?;
+                .map_err(|_| {
+                    warn!("Bearer token missing");
+                    SessionError::InvalidSessionId
+                })?;
 
         Ok(Self(bearer.token().to_owned()))
     }


### PR DESCRIPTION
This needs `LOG_FORMAT=compact` or prettier (since tiny does not include span fields in the event formatter) and verbose output.

With these settings, we can grep for specific user ids (e.g. `github | gswirski`) or trace ids (e.g request `2f06b9ac5a7b9695007599fc8601031f`)

_(text version below)_

<img width="1324" alt="Screenshot 2022-10-18 at 15 13 54" src="https://user-images.githubusercontent.com/35899/196439518-7528c3f9-9b91-436b-9570-89addd43fe08.png">

```
2022-10-18T13:10:27.685235Z  INFO HTTP request: axum_tracing_opentelemetry::middleware: HTTP request span=begin otel.name=GET /auth/callback/github http.client_ip= http.flavor=1.1 http.host=127.0.0.1:3000 http.method=GET http.route=/auth/callback/github http.scheme=HTTP http.target=/auth/callback/github?code=fde4914b5a73c75a5b29&state=eyJyZWRpcmVjdCI6bnVsbH0 http.user_agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Safari/605.1.15 otel.kind=server trace_id=18e887234bee9909ce8ae9420f1bd6bb
2022-10-18T13:10:31.522516Z  WARN HTTP request: kzg_ceremony_sequencer::api::v1::auth: User has already contributed, accepting multiple. uid=github | gswirski otel.name=GET /auth/callback/github http.client_ip= http.flavor=1.1 http.host=127.0.0.1:3000 http.method=GET http.route=/auth/callback/github http.scheme=HTTP http.target=/auth/callback/github?code=fde4914b5a73c75a5b29&state=eyJyZWRpcmVjdCI6bnVsbH0 http.user_agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Safari/605.1.15 otel.kind=server trace_id=18e887234bee9909ce8ae9420f1bd6bb
2022-10-18T13:10:31.525405Z  INFO sqlx::query: SELECT EXISTS(SELECT 1 FROM …; rows affected: 0, rows returned: 1, elapsed: 1.562ms

SELECT
  EXISTS(
    SELECT
      1
    FROM
      contributors
    WHERE
      uid = ?1
  )

2022-10-18T13:10:43.025121Z  INFO HTTP request: axum_tracing_opentelemetry::middleware: HTTP request span=begin otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f
2022-10-18T13:10:43.026281Z  WARN HTTP request: kzg_ceremony_sequencer::api::v1::lobby: user session not found otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f
2022-10-18T13:10:43.026427Z  INFO HTTP request:authenticated user: kzg_ceremony_sequencer::api::v1::lobby: authenticated user span=begin otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f uid="github | gswirski"
2022-10-18T13:10:43.026535Z  INFO HTTP request:authenticated user: kzg_ceremony_sequencer::api::v1::lobby: current contributor set otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f uid="github | gswirski"
2022-10-18T13:10:43.029109Z  INFO sqlx::query: INSERT INTO contributors (uid, …; rows affected: 1, rows returned: 0, elapsed: 1.044ms

INSERT INTO
  contributors (uid, started_at)
VALUES
  (?1, ?2)

2022-10-18T13:10:43.030472Z  INFO HTTP request:authenticated user: kzg_ceremony_sequencer::api::v1::lobby: authenticated user span=end time.busy=3.81ms time.idle=229µs otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f uid="github | gswirski"
2022-10-18T13:10:43.430755Z  INFO HTTP request: axum_tracing_opentelemetry::middleware: HTTP request span=end time.busy=403ms time.idle=2.73ms otel.name=POST /lobby/try_contribute http.client_ip= http.flavor=1.1 http.host=localhost:3000 http.method=POST http.route=/lobby/try_contribute http.scheme=HTTP http.target=/lobby/try_contribute http.user_agent=curl/7.79.1 otel.kind=server trace_id=2f06b9ac5a7b9695007599fc8601031f http.status_code=200 otel.status_code="OK"
```

/cc @recmo since 1) you maintain `cli_batteries` and might want to tweak its default formatters 2) this will likely require changes to the deployment script

