### PR TITLE
Implement the double signing spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "atoi"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1378,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16142eeb3155cfa5aec6be3f828a28513a28bd995534f945fa70e7d608f16c10"
+dependencies = [
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23f8992ecf45ea9dd2983696aabc566c108723585f07f5dc8c9efb24e52d3db"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0010fffc97c5abcf75a30fd75676b1ed917b2b82beb8270391333618e2847d"
+dependencies = [
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "ethers-core"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1449,83 @@ dependencies = [
  "thiserror",
  "tiny-keccak",
  "unicode-xid",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b279a3d00bd219caa2f9a34451b4accbfa9a1eaafc26dcda9d572591528435f0"
+dependencies = [
+ "ethers-core",
+ "getrandom",
+ "reqwest",
+ "semver 1.0.14",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e7e8632d28175352b9454bbcb604643b6ca1de4d36dc99b3f86860d75c132b"
+dependencies = [
+ "async-trait",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46482e4d1e79b20c338fd9db9e166184eb387f0a4e7c05c5b5c0aa2e8c8900c"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.13.0",
+ "ethers-core",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "getrandom",
+ "hashers",
+ "hex",
+ "http",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-timer",
+ "web-sys",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1601,6 +1733,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
+name = "futures-locks"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb42d4fb72227be5778429f9ef5240a38a358925a49f05b5cf702ce7c7e558a"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+ "tokio",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1788,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1728,6 +1886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
 ]
 
 [[package]]
@@ -2025,6 +2192,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2100,6 +2270,7 @@ dependencies = [
  "ark-ff",
  "blst",
  "criterion",
+ "ethers",
  "hex",
  "hex-literal",
  "proptest",
@@ -2676,6 +2847,16 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -3392,12 +3573,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
+
+[[package]]
 name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-aux"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a77223b653fa95f3f9864f3eb25b93e4ed170687eb42d85b6b98af21d5e1de"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4513,6 +4710,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4856,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -274,17 +273,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -712,11 +700,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array 0.14.6",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -862,7 +851,7 @@ dependencies = [
  "getrandom",
  "hex",
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "rand",
  "sha2 0.10.6",
  "thiserror",
@@ -931,9 +920,12 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1113,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -1179,6 +1171,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1310,16 +1313,16 @@ dependencies = [
 
 [[package]]
 name = "eth-keystore"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f65b750ac950f2f825b36d08bef4cda4112e19a7b1a68f6e2bb499413e12440"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
  "aes",
  "ctr",
  "digest 0.10.5",
  "hex",
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "rand",
  "scrypt",
  "serde",
@@ -1355,8 +1358,10 @@ checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
  "fixed-hash",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "scale-info",
  "tiny-keccak",
 ]
 
@@ -1368,61 +1373,19 @@ checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
  "fixed-hash",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
  "primitive-types",
+ "scale-info",
  "uint",
 ]
 
 [[package]]
-name = "ethers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16142eeb3155cfa5aec6be3f828a28513a28bd995534f945fa70e7d608f16c10"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23f8992ecf45ea9dd2983696aabc566c108723585f07f5dc8c9efb24e52d3db"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0010fffc97c5abcf75a30fd75676b1ed917b2b82beb8270391333618e2847d"
-dependencies = [
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "hex",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "ethers-core"
-version = "0.17.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
+checksum = "06338c311c6a0a7ed04877d0fb0f0d627ed390aaa3429b4e041b8d17348a506d"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1430,10 +1393,10 @@ dependencies = [
  "convert_case",
  "elliptic-curve",
  "ethabi",
- "fastrlp",
  "generic-array 0.14.6",
  "hex",
  "k256",
+ "open-fastrlp",
  "proc-macro2",
  "rand",
  "rlp",
@@ -1449,87 +1412,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers-etherscan"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b279a3d00bd219caa2f9a34451b4accbfa9a1eaafc26dcda9d572591528435f0"
-dependencies = [
- "ethers-core",
- "getrandom",
- "reqwest",
- "semver 1.0.14",
- "serde",
- "serde-aux",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7e8632d28175352b9454bbcb604643b6ca1de4d36dc99b3f86860d75c132b"
-dependencies = [
- "async-trait",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46482e4d1e79b20c338fd9db9e166184eb387f0a4e7c05c5b5c0aa2e8c8900c"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.13.1",
- "ethers-core",
- "futures-core",
- "futures-timer",
- "futures-util",
- "getrandom",
- "hashers",
- "hex",
- "http",
- "once_cell",
- "parking_lot 0.11.2",
- "pin-project",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-timer",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
 name = "ethers-signers"
-version = "0.17.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a72ecad124e8ccd18d6a43624208cab0199e59621b1f0fa6b776b2e0529107"
+checksum = "f1f97da069cd77dd91a0a7f0c979f063a4bf9d2533b277ff5ccb19b7ac348376"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1572,31 +1458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
-dependencies = [
- "arrayvec 0.7.2",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "fastrlp-derive",
-]
-
-[[package]]
-name = "fastrlp-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e9158c1d8f0a7a716c9191562eaabba70268ba64972ef4871ce8d66fd08872"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1720,7 +1581,7 @@ checksum = "1b6bdbb8c5a42b2bb5ee8dd9dc2c7d73ce3e15d26dfe100fb347ffa3f58c672b"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1728,17 +1589,6 @@ name = "futures-io"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
-
-[[package]]
-name = "futures-locks"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb42d4fb72227be5778429f9ef5240a38a358925a49f05b5cf702ce7c7e558a"
-dependencies = [
- "futures-channel",
- "futures-task",
- "tokio",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1764,12 +1614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,15 +1629,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1883,15 +1718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
 ]
 
 [[package]]
@@ -2183,15 +2009,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2267,7 +2099,7 @@ dependencies = [
  "ark-ff",
  "blst",
  "criterion",
- "ethers",
+ "ethers-core",
  "hex",
  "hex-literal",
  "proptest",
@@ -2295,7 +2127,6 @@ dependencies = [
  "chrono",
  "clap 4.0.18",
  "cli-batteries",
- "ethers",
  "ethers-core",
  "ethers-signers",
  "eyre",
@@ -2623,6 +2454,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open-fastrlp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131de184f045153e72c537ef4f1d57babddf2a897ca19e67bdff697aebba7f3d"
+dependencies = [
+ "arrayvec 0.7.2",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,37 +2584,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2772,17 +2603,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -2804,22 +2624,13 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest 0.10.5",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.5",
  "hmac 0.12.1",
- "password-hash 0.4.2",
+ "password-hash",
  "sha2 0.10.6",
 ]
 
@@ -2847,16 +2658,6 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -2951,6 +2752,7 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -3022,7 +2824,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot",
  "procfs",
  "protobuf",
  "thiserror",
@@ -3474,9 +3276,9 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "salsa20"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
@@ -3488,6 +3290,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333af15b02563b8182cd863f925bd31ef8fa86a0e095d30c091956057d436153"
+dependencies = [
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f56acbd0743d29ffa08f911ab5397def774ad01bab3786804cf6ee057fb5e1"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3504,13 +3330,12 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "scrypt"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73d6d7c6311ebdbd9184ad6c4447b2f36337e327bda107d3ba9e3c374f9d325"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
  "hmac 0.12.1",
- "password-hash 0.3.2",
- "pbkdf2 0.10.1",
+ "pbkdf2",
  "salsa20",
  "sha2 0.10.6",
 ]
@@ -3573,28 +3398,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
-
-[[package]]
 name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-aux"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a77223b653fa95f3f9864f3eb25b93e4ed170687eb42d85b6b98af21d5e1de"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4150,7 +3959,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4456,7 +4265,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",
@@ -4728,21 +4537,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,24 +4725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "pharos",
- "rustc_version 0.4.0",
- "send_wrapper",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,8 @@ base64 = "0.13"
 chrono = "0.4"
 clap = { version = "4.0", features = ["derive"] }
 cli-batteries = { version = "0.4.0", features = ["signals", "prometheus", "metered-allocator", "otlp"] }
-ethers-core = "0.17.0"
-ethers-signers = "0.17.0"
-ethers = "0.17.0"
+ethers-core = "1.0.0"
+ethers-signers = "1.0.0"
 eyre = "0.6.8"
 headers = "0.3"
 hex = "0.4.3"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,23 +12,23 @@ readme = "Readme.md"
 license-file = "../mit-license.md"
 
 [features]
-default = [ ]
-bench = [ "criterion" ]
-arkworks = [ "dep:ruint" ]
-blst = [ "dep:blst" ]
+default = []
+bench = ["criterion"]
+arkworks = ["dep:ruint"]
+blst = ["dep:blst"]
 
 [[bench]]
 name = "criterion"
 harness = false
 path = "criterion.rs"
-required-features = [ "bench" ]
+required-features = ["bench"]
 
 [dependencies]
 criterion = { version = "0.4.0", optional = true } # Dev dep for bench
 ark-bls12-381 = "0.3.0"
 ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-ff = { version = "0.3.0", features = ["parallel", "asm"] }
-blst = { version = "0.3.10", optional = true}
+blst = { version = "0.3.10", optional = true }
 hex = "0.4.3"
 rand = "0.8.5"
 rayon = "1.5.3"
@@ -41,6 +41,7 @@ zeroize = "1.5.7"
 hex-literal = "0.3.4"
 rand_chacha = "0.3.1"
 secrecy = "0.8.0"
+ethers = { version = "0.17.0" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -29,7 +29,7 @@ ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-ff = { version = "0.3.0", features = ["parallel", "asm"] }
 blst = { version = "0.3.10", optional = true }
 criterion = { version = "0.4.0", optional = true } # Dev dep for bench
-ethers = "0.17.0"
+ethers-core = { version = "1.0.0", features = ["eip712"] }
 hex = "0.4.3"
 hex-literal = "0.3.4"
 rand = "0.8.5"

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -57,6 +57,7 @@ pub mod bench {
         Arkworks, BatchTranscript, Both, BLST,
     };
     use criterion::{BatchSize, Criterion};
+    use crate::signature::identity::Identity;
 
     pub fn group(criterion: &mut Criterion) {
         #[cfg(feature = "arkworks")]
@@ -73,7 +74,9 @@ pub mod bench {
             let mut transcript = BatchTranscript::new(BATCH_SIZE.iter());
             let mut contribution = transcript.contribution();
             contribution.add_entropy::<E>(&rand_entropy()).unwrap();
-            transcript.verify_add::<E>(contribution).unwrap();
+            transcript
+                .verify_add::<E>(contribution, Identity::None)
+                .unwrap();
             transcript
         };
 

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -1,4 +1,4 @@
-use crate::{CeremoniesError, Contribution, Engine, Entropy, Tau, G2};
+use crate::{signature::EcdsaSignature, CeremoniesError, Contribution, Engine, Entropy, Tau, G2};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
@@ -9,7 +9,8 @@ use tracing::instrument;
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BatchContribution {
-    pub contributions: Vec<Contribution>,
+    pub contributions:   Vec<Contribution>,
+    pub ecdsa_signature: Option<EcdsaSignature>,
 }
 
 impl BatchContribution {

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 #[serde(deny_unknown_fields)]
 pub struct BatchContribution {
     pub contributions:   Vec<Contribution>,
-    pub ecdsa_signature: Option<EcdsaSignature>,
+    pub ecdsa_signature: EcdsaSignature,
 }
 
 impl BatchContribution {

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -1,4 +1,7 @@
-use crate::{signature::EcdsaSignature, CeremoniesError, Contribution, Engine, Entropy, Tau, G2};
+use crate::{
+    signature::{identity::Identity, EcdsaSignature},
+    CeremoniesError, Contribution, Engine, Entropy, Tau, G2,
+};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
@@ -20,7 +23,11 @@ impl BatchContribution {
     }
 
     #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]
-    pub fn add_entropy<E: Engine>(&mut self, entropy: &Entropy) -> Result<(), CeremoniesError> {
+    pub fn add_entropy<E: Engine>(
+        &mut self,
+        entropy: &Entropy,
+        identity: &Identity,
+    ) -> Result<(), CeremoniesError> {
         let taus = derive_taus::<E>(entropy, self.contributions.len());
         let res = self
             .contributions
@@ -29,7 +36,7 @@ impl BatchContribution {
             .enumerate()
             .try_for_each(|(i, (contribution, tau))| {
                 contribution
-                    .add_tau::<E>(tau)
+                    .add_tau::<E>(tau, identity)
                     .map_err(|e| CeremoniesError::InvalidCeremony(i, e))
             });
         res
@@ -54,10 +61,10 @@ pub mod bench {
     use super::*;
     use crate::{
         bench::{rand_entropy, BATCH_SIZE},
+        signature::identity::Identity,
         Arkworks, BatchTranscript, Both, BLST,
     };
     use criterion::{BatchSize, Criterion};
-    use crate::signature::identity::Identity;
 
     pub fn group(criterion: &mut Criterion) {
         #[cfg(feature = "arkworks")]
@@ -73,7 +80,9 @@ pub mod bench {
         let transcript = {
             let mut transcript = BatchTranscript::new(BATCH_SIZE.iter());
             let mut contribution = transcript.contribution();
-            contribution.add_entropy::<E>(&rand_entropy()).unwrap();
+            contribution
+                .add_entropy::<E>(&rand_entropy(), &Identity::None)
+                .unwrap();
             transcript
                 .verify_add::<E>(contribution, Identity::None)
                 .unwrap();
@@ -86,7 +95,9 @@ pub mod bench {
                 bencher.iter_batched(
                     || (transcript.contribution(), rand_entropy()),
                     |(mut contribution, entropy)| {
-                        contribution.add_entropy::<E>(&entropy).unwrap();
+                        contribution
+                            .add_entropy::<E>(&entropy, &Identity::None)
+                            .unwrap();
                     },
                     BatchSize::LargeInput,
                 );

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -69,7 +69,6 @@ impl BatchTranscript {
                     .map_err(|e| CeremoniesError::InvalidCeremony(i, e))
             })?;
 
-        self.participant_ids.push(identity);
         self.participant_ecdsa_signatures.push(
             contribution
                 .ecdsa_signature
@@ -84,6 +83,8 @@ impl BatchTranscript {
         {
             transcript.add(contribution);
         }
+
+        self.participant_ids.push(identity);
 
         Ok(())
     }

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -1,4 +1,7 @@
-use crate::{BatchContribution, CeremoniesError, Engine, Transcript};
+use crate::{
+    signature::{identity::Identity, EcdsaSignature},
+    BatchContribution, CeremoniesError, Engine, Transcript,
+};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -6,7 +9,9 @@ use tracing::instrument;
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BatchTranscript {
-    pub transcripts: Vec<Transcript>,
+    pub transcripts:                  Vec<Transcript>,
+    pub participant_ids:              Vec<Identity>,
+    pub participant_ecdsa_signatures: Vec<EcdsaSignature>,
 }
 
 impl BatchTranscript {
@@ -15,10 +20,12 @@ impl BatchTranscript {
         I: IntoIterator<Item = &'a (usize, usize)> + 'a,
     {
         Self {
-            transcripts: iter
+            transcripts:                  iter
                 .into_iter()
                 .map(|(num_g1, num_g2)| Transcript::new(*num_g1, *num_g2))
                 .collect(),
+            participant_ids:              vec![],
+            participant_ecdsa_signatures: vec![],
         }
     }
 

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -24,8 +24,8 @@ impl BatchTranscript {
                 .into_iter()
                 .map(|(num_g1, num_g2)| Transcript::new(*num_g1, *num_g2))
                 .collect(),
-            participant_ids:              vec![],
-            participant_ecdsa_signatures: vec![],
+            participant_ids:              vec![Identity::None],
+            participant_ecdsa_signatures: vec![EcdsaSignature::empty()],
         }
     }
 
@@ -48,6 +48,7 @@ impl BatchTranscript {
     pub fn verify_add<E: Engine>(
         &mut self,
         contribution: BatchContribution,
+        identity: Identity,
     ) -> Result<(), CeremoniesError> {
         // Verify contribution count
         if self.transcripts.len() != contribution.contributions.len() {
@@ -76,6 +77,8 @@ impl BatchTranscript {
         {
             transcript.add(contribution);
         }
+
+        self.participant_ids.push(identity);
 
         Ok(())
     }

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -33,11 +33,12 @@ impl BatchTranscript {
     #[must_use]
     pub fn contribution(&self) -> BatchContribution {
         BatchContribution {
-            contributions: self
+            contributions:   self
                 .transcripts
                 .iter()
                 .map(Transcript::contribution)
                 .collect(),
+            ecdsa_signature: None,
         }
     }
 

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -115,7 +115,9 @@ pub mod bench {
             let mut transcript = BatchTranscript::new(BATCH_SIZE.iter());
             let mut contribution = transcript.contribution();
             contribution.add_entropy::<E>(&rand_entropy()).unwrap();
-            transcript.verify_add::<E>(contribution).unwrap();
+            transcript
+                .verify_add::<E>(contribution, Identity::None)
+                .unwrap();
             transcript
         };
 
@@ -131,7 +133,9 @@ pub mod bench {
                         })
                     },
                     |(mut transcript, contribution)| {
-                        transcript.verify_add::<E>(contribution).unwrap();
+                        transcript
+                            .verify_add::<E>(contribution, Identity::None)
+                            .unwrap();
                     },
                     BatchSize::LargeInput,
                 );

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -1,4 +1,4 @@
-use crate::{CeremonyError, Engine, Powers, Tau, G2};
+use crate::{signature::BlsSignature, CeremonyError, Engine, Powers, Tau, G2};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -6,9 +6,9 @@ use tracing::instrument;
 #[serde(rename_all = "camelCase")]
 pub struct Contribution {
     #[serde(flatten)]
-    pub powers: Powers,
-
-    pub pot_pubkey: G2,
+    pub powers:        Powers,
+    pub pot_pubkey:    G2,
+    pub bls_signature: BlsSignature,
 }
 
 impl Contribution {
@@ -46,28 +46,30 @@ mod test {
     #[test]
     fn contribution_json() {
         let value = Contribution {
-            powers:     Powers::new(2, 4),
-            pot_pubkey: G2::one(),
+            powers:        Powers::new(2, 4),
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
         };
         let json = serde_json::to_value(&value).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
-            "numG1Powers": 2,
-            "numG2Powers": 4,
-            "powersOfTau": {
-                "G1Powers": [
-                "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
-                "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
-                ],
-                "G2Powers": [
-                "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
-                "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
-                "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
-                "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
-                ]
-            },
-            "potPubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+                "numG1Powers": 2,
+                "numG2Powers": 4,
+                "powersOfTau": {
+                    "G1Powers": [
+                    "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
+                    "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+                    ],
+                    "G2Powers": [
+                    "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+                    "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+                    "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+                    "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+                    ]
+                },
+                "potPubkey": "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+                "blsSignature": ""
             })
         );
         let deser = serde_json::from_value::<Contribution>(json).unwrap();

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -169,6 +169,18 @@ impl Engine for Arkworks {
         }
         Ok(())
     }
+
+    fn sign_message(_tau: &Tau, _message: &[u8]) -> Option<G1> {
+        // TODO implement this. This behavior is still spec-conforming, since signatures
+        // are optional.
+        None
+    }
+
+    fn verify_signature(_sig: G1, _message: &[u8], _pk: G2) -> bool {
+        // TODO implement this. This behavior is still spec-conforming, since singatures
+        // are optional.
+        false
+    }
 }
 
 pub fn powers_of_tau(tau: &Tau, n: usize) -> SecretVec<Fr> {

--- a/crypto/src/engine/blst/g1.rs
+++ b/crypto/src/engine/blst/g1.rs
@@ -32,6 +32,14 @@ impl TryFrom<blst_p1_affine> for G1 {
     }
 }
 
+impl TryFrom<blst_p1> for G1 {
+    type Error = ParseError;
+
+    fn try_from(g1: blst_p1) -> Result<Self, Self::Error> {
+        Self::try_from(p1_to_affine(&g1))
+    }
+}
+
 pub fn p1_from_affine(a: &blst_p1_affine) -> blst_p1 {
     unsafe {
         let mut p = blst_p1::default();

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -200,10 +200,10 @@ impl Engine for BLST {
                 message.len(),
                 Self::CYPHER_SUITE.as_ptr(),
                 Self::CYPHER_SUITE.len(),
-                [0 as u8; 0].as_ptr(),
+                [0; 0].as_ptr(),
                 0,
             );
-            blst_sign_pk_in_g2(&mut sig, &mut hash, &sk);
+            blst_sign_pk_in_g2(&mut sig, &hash, &sk);
         }
         G1::try_from(sig).ok()
     }
@@ -226,7 +226,7 @@ impl Engine for BLST {
                 message.len(),
                 Self::CYPHER_SUITE.as_ptr(),
                 Self::CYPHER_SUITE.len(),
-                [0 as u8; 0].as_ptr(),
+                [0; 0].as_ptr(),
                 0,
             )
         };

--- a/crypto/src/engine/blst/scalar.rs
+++ b/crypto/src/engine/blst/scalar.rs
@@ -77,6 +77,16 @@ pub fn scalar_from_u64(a: u64) -> blst_scalar {
     scalar
 }
 
+impl From<&F> for blst_scalar {
+    fn from(n: &F) -> Self {
+        let mut out = blst_scalar::default();
+        unsafe {
+            blst_scalar_from_lendian(&mut out, n.0.as_ptr());
+        }
+        out
+    }
+}
+
 impl From<&F> for blst_fr {
     fn from(n: &F) -> Self {
         // TODO: Zeroize the temps

--- a/crypto/src/engine/blst/scalar.rs
+++ b/crypto/src/engine/blst/scalar.rs
@@ -79,7 +79,7 @@ pub fn scalar_from_u64(a: u64) -> blst_scalar {
 
 impl From<&F> for blst_scalar {
     fn from(n: &F) -> Self {
-        let mut out = blst_scalar::default();
+        let mut out = Self::default();
         unsafe {
             blst_scalar_from_lendian(&mut out, n.0.as_ptr());
         }

--- a/crypto/src/engine/both.rs
+++ b/crypto/src/engine/both.rs
@@ -77,7 +77,7 @@ impl<A: Engine, B: Engine> Engine for Both<A, B> {
 
     fn sign_message(tau: &Tau, message: &[u8]) -> Option<G1> {
         // TODO: Use both engines, when Arkworks support added
-        A::sign_message(tau, message).or(B::sign_message(tau, message))
+        A::sign_message(tau, message).or_else(|| B::sign_message(tau, message))
     }
 
     fn verify_signature(sig: G1, message: &[u8], pk: G2) -> bool {

--- a/crypto/src/engine/both.rs
+++ b/crypto/src/engine/both.rs
@@ -74,4 +74,14 @@ impl<A: Engine, B: Engine> Engine for Both<A, B> {
         assert_eq!(powers, &b[..]);
         Ok(())
     }
+
+    fn sign_message(tau: &Tau, message: &[u8]) -> Option<G1> {
+        // TODO: Use both engines, when Arkworks support added
+        A::sign_message(tau, message).or(B::sign_message(tau, message))
+    }
+
+    fn verify_signature(sig: G1, message: &[u8], pk: G2) -> bool {
+        // TODO: Use both engines, when Arkworks support added
+        A::verify_signature(sig, message, pk) || B::verify_signature(sig, message, pk)
+    }
 }

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -26,6 +26,8 @@ pub type Entropy = Secret<[u8; 32]>;
 pub type Tau = Secret<F>;
 
 pub trait Engine {
+    const CYPHER_SUITE: &'static str = "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
+
     /// Verifies that the given G1 points are valid.
     ///
     /// Valid mean that they are uniquely encoded in compressed ZCash format and
@@ -56,10 +58,16 @@ pub trait Engine {
 
     /// Multiply elements of `powers` by powers of $τ$.
     fn add_tau_g2(tau: &Tau, powers: &mut [G2]) -> Result<(), CeremonyError>;
+
+    /// Sign a message with `CYPHER_SUITE`, using $τ$ as the secret key.
+    fn sign_message(tau: &Tau, message: &[u8]) -> Option<G1>;
+
+    /// Verify a `CYPHER_SUITE` signature.
+    fn verify_signature(sig: G1, message: &[u8], pk: G2) -> bool;
 }
 
 #[cfg(all(test, feature = "arkworks", feature = "blst"))]
-mod tests {
+pub mod tests {
     use super::*;
     use proptest::{proptest, strategy::Strategy};
 

--- a/crypto/src/group.rs
+++ b/crypto/src/group.rs
@@ -1,8 +1,8 @@
 //! BLS12-381 group elements in ZCash encoding.
 
+use crate::hex_format::{bytes_to_hex, hex_to_bytes};
 use hex_literal::hex;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::Zeroize;
 
 /// A scalar field element.
@@ -99,97 +99,5 @@ impl Serialize for G2 {
 impl<'de> Deserialize<'de> for G2 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         hex_to_bytes(deserializer).map(Self)
-    }
-}
-
-/// Allocation free hex serializer with `0x` prefix.
-///
-/// Constant generic `N` is the length of the byte array. The value
-/// `M` must be set to `2 + 2 * N`.
-fn bytes_to_hex<S: Serializer, const N: usize, const M: usize>(
-    serializer: S,
-    bytes: [u8; N],
-) -> Result<S::Ok, S::Error> {
-    assert_eq!(2 + 2 * N, M);
-    if serializer.is_human_readable() {
-        let mut hex = [0_u8; M];
-        hex[0] = b'0';
-        hex[1] = b'x';
-        hex::encode_to_slice(bytes, &mut hex[2..])
-            .expect("BUG: output buffer is of the correct size");
-        let str = std::str::from_utf8(&hex).expect("BUG: hex is valid UTF-8");
-        serializer.serialize_str(str)
-    } else {
-        serializer.serialize_bytes(&bytes)
-    }
-}
-
-/// Allocation free hex deserializer with `0x` prefix.
-fn hex_to_bytes<'de, D: Deserializer<'de>, const N: usize>(
-    deserializer: D,
-) -> Result<[u8; N], D::Error> {
-    if deserializer.is_human_readable() {
-        deserializer.deserialize_str(StrVisitor::<N>)
-    } else {
-        deserializer.deserialize_bytes(ByteVisitor::<N>)
-    }
-}
-
-/// Serde Visitor for human readable formats. Requires `0x` prefix, but is
-/// otherwise case insensitive.
-struct StrVisitor<const N: usize>;
-
-impl<'de, const N: usize> de::Visitor<'de> for StrVisitor<N> {
-    type Value = [u8; N];
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "a {} byte hex string stating with `0x`", N)
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        let mut result = [0_u8; N];
-        if value.len() != 2 + 2 * N {
-            return Err(E::invalid_length(value.len(), &self));
-        }
-        if &value[..2] != "0x" {
-            return Err(E::custom("hex string must start with `0x`"));
-        }
-        if !value[2..]
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-        {
-            return Err(E::custom(
-                "hex string must contain only lower-case hex digits",
-            ));
-        }
-        hex::decode_to_slice(&value[2..], &mut result)
-            .map_err(|e| E::custom(format!("hex decoding failed: {}", e)))?;
-        Ok(result)
-    }
-}
-
-/// Serde Visitor for non-human readable formats
-struct ByteVisitor<const N: usize>;
-
-impl<'de, const N: usize> de::Visitor<'de> for ByteVisitor<N> {
-    type Value = [u8; N];
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{N} bytes of binary data")
-    }
-
-    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        if value.len() != N {
-            return Err(E::invalid_length(value.len(), &self));
-        }
-        let mut result = [0_u8; N];
-        result.copy_from_slice(value);
-        Ok(result)
     }
 }

--- a/crypto/src/hex_format.rs
+++ b/crypto/src/hex_format.rs
@@ -1,0 +1,111 @@
+use crate::hex_format::HexDecodingError::{
+    DecoderError, InvalidCharacter, InvalidLength, MissingPrefix,
+};
+use hex::FromHexError;
+use serde::{de, Deserializer, Serializer};
+use std::fmt;
+
+/// Allocation free hex serializer with `0x` prefix.
+///
+/// Constant generic `N` is the length of the byte array. The value
+/// `M` must be set to `2 + 2 * N`.
+pub fn bytes_to_hex<S: Serializer, const N: usize, const M: usize>(
+    serializer: S,
+    bytes: [u8; N],
+) -> Result<S::Ok, S::Error> {
+    assert_eq!(2 + 2 * N, M);
+    if serializer.is_human_readable() {
+        let mut hex = [0_u8; M];
+        hex[0] = b'0';
+        hex[1] = b'x';
+        hex::encode_to_slice(bytes, &mut hex[2..])
+            .expect("BUG: output buffer is of the correct size");
+        let str = std::str::from_utf8(&hex).expect("BUG: hex is valid UTF-8");
+        serializer.serialize_str(str)
+    } else {
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+/// Allocation free hex deserializer with `0x` prefix.
+pub fn hex_to_bytes<'de, D: Deserializer<'de>, const N: usize>(
+    deserializer: D,
+) -> Result<[u8; N], D::Error> {
+    if deserializer.is_human_readable() {
+        deserializer.deserialize_str(StrVisitor::<N>)
+    } else {
+        deserializer.deserialize_bytes(ByteVisitor::<N>)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HexDecodingError {
+    #[error("input length must equal {0}")]
+    InvalidLength(usize),
+    #[error("hex string must start with `0x`")]
+    MissingPrefix,
+    #[error("hex string must contain only lower-case hex digits")]
+    InvalidCharacter,
+    #[error("hex decoding failed: {0}")]
+    DecoderError(FromHexError),
+}
+
+pub fn hex_str_to_bytes<const N: usize>(value: &str) -> Result<[u8; N], HexDecodingError> {
+    let mut result = [0_u8; N];
+    if value.len() != 2 + 2 * N {
+        return Err(InvalidLength(2 + 2 * N));
+    }
+    if &value[..2] != "0x" {
+        return Err(MissingPrefix);
+    }
+    if !value[2..]
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        return Err(InvalidCharacter);
+    }
+    hex::decode_to_slice(&value[2..], &mut result).map_err(DecoderError)?;
+    Ok(result)
+}
+
+/// Serde Visitor for human readable formats. Requires `0x` prefix, but is
+/// otherwise case insensitive.
+struct StrVisitor<const N: usize>;
+
+impl<'de, const N: usize> de::Visitor<'de> for StrVisitor<N> {
+    type Value = [u8; N];
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a {} byte hex string stating with `0x`", N)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        hex_str_to_bytes(value).map_err(E::custom)
+    }
+}
+
+/// Serde Visitor for non-human readable formats
+struct ByteVisitor<const N: usize>;
+
+impl<'de, const N: usize> de::Visitor<'de> for ByteVisitor<N> {
+    type Value = [u8; N];
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{N} bytes of binary data")
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if value.len() != N {
+            return Err(E::invalid_length(value.len(), &self));
+        }
+        let mut result = [0_u8; N];
+        result.copy_from_slice(value);
+        Ok(result)
+    }
+}

--- a/crypto/src/hex_format.rs
+++ b/crypto/src/hex_format.rs
@@ -82,7 +82,7 @@ impl<'de, const N: usize> de::Visitor<'de> for StrVisitor<N> {
     type Value = [u8; N];
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "a {} byte hex string stating with `0x`", N)
+        write!(formatter, "a {N} byte hex string stating with `0x`")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -9,6 +9,7 @@ mod contribution;
 mod engine;
 mod error;
 mod group;
+mod hex_format;
 mod powers;
 mod signature;
 mod transcript;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -11,7 +11,7 @@ mod error;
 mod group;
 mod hex_format;
 mod powers;
-mod signature;
+pub mod signature;
 mod transcript;
 
 pub use crate::{

--- a/crypto/src/signature/identity.rs
+++ b/crypto/src/signature/identity.rs
@@ -10,6 +10,11 @@ pub enum Identity {
 }
 
 impl Identity {
+    /// Parse Ethereum identity from address from hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError`] if the input is not a valid Ethereum address.
     pub fn eth_from_str(address: &str) -> Result<Self, IdentityError> {
         if address.len() != 42 || &address[..2] != "0x" {
             return Err(IdentityError::InvalidEthereumAddress);

--- a/crypto/src/signature/identity.rs
+++ b/crypto/src/signature/identity.rs
@@ -10,7 +10,7 @@ pub enum Identity {
 }
 
 impl Identity {
-    pub fn eth_from_str(address: &str) -> Result<Identity, IdentityError> {
+    pub fn eth_from_str(address: &str) -> Result<Self, IdentityError> {
         if address.len() != 42 || &address[..2] != "0x" {
             return Err(IdentityError::InvalidEthereumAddress);
         }
@@ -19,13 +19,15 @@ impl Identity {
             .try_into()
             .map_err(|_| IdentityError::InvalidEthereumAddress)?;
 
-        Ok(Identity::Ethereum { address })
+        Ok(Self::Ethereum { address })
     }
 
+    #[must_use]
     pub fn unique_id(&self) -> String {
         self.to_string()
     }
 
+    #[must_use]
     pub fn nickname(&self) -> String {
         match self {
             Self::Ethereum { address } => format!("0x{}", hex::encode(address)),
@@ -34,6 +36,7 @@ impl Identity {
         }
     }
 
+    #[must_use]
     pub fn provider_name(&self) -> String {
         match self {
             Self::Ethereum { .. } => "Ethereum",
@@ -61,9 +64,9 @@ pub enum IdentityError {
 impl Display for Identity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Identity::None => write!(f, ""),
-            Identity::Ethereum { address } => write!(f, "eth|0x{}", hex::encode(address)),
-            Identity::Github { id, username } => write!(f, "git|{}|{}", id, username),
+            Self::None => write!(f, ""),
+            Self::Ethereum { address } => write!(f, "eth|0x{}", hex::encode(address)),
+            Self::Github { id, username } => write!(f, "git|{}|{}", id, username),
         }
     }
 }
@@ -88,7 +91,7 @@ impl FromStr for Identity {
                     .try_into()
                     .map_err(|_| IdentityError::InvalidEthereumAddress)?;
 
-                Ok(Identity::Ethereum { address })
+                Ok(Self::Ethereum { address })
             }
             Some("git") => {
                 let id = parts.next().ok_or(IdentityError::MissingField)?;
@@ -100,13 +103,13 @@ impl FromStr for Identity {
                 let id = id.parse().map_err(|_| IdentityError::InvalidGithubId)?;
                 let username = username.to_string();
 
-                Ok(Identity::Github { id, username })
+                Ok(Self::Github { id, username })
             }
             Some("") => {
                 if parts.next().is_some() {
                     return Err(IdentityError::TooManyFields);
                 }
-                Ok(Identity::None)
+                Ok(Self::None)
             }
             _ => Err(IdentityError::UnsupportedType),
         }

--- a/crypto/src/signature/identity.rs
+++ b/crypto/src/signature/identity.rs
@@ -4,9 +4,40 @@ use thiserror::Error;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Identity {
-    None,
     Ethereum { address: [u8; 20] },
     Github { id: u64, username: String },
+}
+
+impl Identity {
+    pub fn eth_from_str(address: &str) -> Result<Identity, IdentityError> {
+        if address.len() != 42 || &address[..2] != "0x" {
+            return Err(IdentityError::InvalidEthereumAddress);
+        }
+        let address = hex::decode(&address[2..])
+            .map_err(|_| IdentityError::InvalidEthereumAddress)?
+            .try_into()
+            .map_err(|_| IdentityError::InvalidEthereumAddress)?;
+
+        Ok(Identity::Ethereum { address })
+    }
+
+    pub fn unique_id(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn nickname(&self) -> String {
+        match self {
+            Self::Ethereum { address } => format!("0x{}", hex::encode(address)),
+            Self::Github { username, .. } => username.to_string(),
+        }
+    }
+
+    pub fn provider_name(&self) -> String {
+        match self {
+            Self::Ethereum { .. } => "Ethereum",
+            Self::Github { .. } => "Github",
+        }.to_string()
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Error)]
@@ -26,7 +57,6 @@ pub enum IdentityError {
 impl Display for Identity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Identity::None => write!(f, ""),
             Identity::Ethereum { address } => write!(f, "eth|0x{}", hex::encode(address)),
             Identity::Github { id, username } => write!(f, "git|{}|{}", id, username),
         }
@@ -67,12 +97,6 @@ impl FromStr for Identity {
 
                 Ok(Identity::Github { id, username })
             }
-            Some("") => {
-                if parts.next().is_some() {
-                    return Err(IdentityError::TooManyFields);
-                }
-                Ok(Identity::None)
-            }
             _ => Err(IdentityError::UnsupportedType),
         }
     }
@@ -100,13 +124,6 @@ impl<'de> Deserialize<'de> for Identity {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_none() {
-        let identity = Identity::None;
-        assert_eq!(identity.to_string(), "");
-        assert_eq!(identity, "".parse().unwrap());
-    }
 
     #[test]
     fn test_eth() {

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -2,9 +2,16 @@
 //! https://github.com/ethereum/kzg-ceremony-specs/blob/master/docs/cryptography/contributionSigning.md
 //! https://github.com/gakonst/ethers-rs/blob/e89c7a378bba6587e3f525982785c59a33c14d9b/ethers-core/ethers-derive-eip712/tests/derive_eip712.rs
 
-mod identity;
+pub mod identity;
 
-use crate::G1;
+use crate::{
+    hex_format::{bytes_to_hex, hex_str_to_bytes},
+    G1, G2,
+};
+use ethers::types::transaction::eip712::{EIP712Domain, Eip712, Eip712Error, TypedData};
+use serde::{de, de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
+use std::fmt::Formatter;
 
 #[allow(unused)]
 pub enum BlsSignature {
@@ -13,9 +20,130 @@ pub enum BlsSignature {
     String(String),
 }
 
-#[allow(unused)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum EcdsaSignature {
     None,
-    G1(G1),
-    String(String),
+    Signature(ethers::types::Signature),
+}
+
+impl Serialize for EcdsaSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::None => serializer.serialize_str(""),
+            Self::Signature(sig) => {
+                let bytes = <[u8; 65]>::from(sig);
+                bytes_to_hex::<_, 65, 132>(serializer, bytes)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for EcdsaSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(EcdsaVisitor)
+    }
+}
+
+struct EcdsaVisitor;
+
+impl<'de> de::Visitor<'de> for EcdsaVisitor {
+    type Value = EcdsaSignature;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(
+            formatter,
+            "expecting a 65 byte hex string starting with `0x`"
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if v.is_empty() {
+            Ok(EcdsaSignature::None)
+        } else {
+            hex_str_to_bytes::<65>(v).map_err(E::custom).map(|bytes| {
+                EcdsaSignature::Signature(
+                    ethers::types::Signature::try_from(&bytes[..])
+                        .expect("Impossible, input is guaranteed correct"),
+                )
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PubkeyTypedData {
+    num_g1_powers: u64,
+    num_g2_powers: u64,
+    pot_pubkey:    G2,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContributionTypedData {
+    pot_pubkeys: Vec<PubkeyTypedData>,
+}
+
+impl From<ContributionTypedData> for TypedData {
+    fn from(contrib: ContributionTypedData) -> Self {
+        let json = json!({
+            "types": {
+                "EIP712Domain": [
+                    {"name":"name", "type":"string"},
+                    {"name":"version", "type":"string"},
+                    {"name":"chainId", "type":"uint256"}
+                ],
+                "contributionPubkey": [
+                    {"name": "numG1Powers", "type": "uint256"},
+                    {"name": "numG2Powers", "type": "uint256"},
+                    {"name": "potPubkey", "type": "bytes"}
+                ],
+                "PoTPubkeys": [
+                    { "name": "potPubkeys", "type": "contributionPubkey[]"}
+                ]
+            },
+            "primaryType": "PoTPubkeys",
+            "domain": {
+                "name": "Ethereum KZG Ceremony",
+                "version": "1.0",
+                "chainId": 1
+            },
+            "message": contrib
+        });
+        return serde_json::from_value(json)
+            .expect("Impossible, constructed from a literal and therefore must be valid json");
+    }
+}
+
+impl Eip712 for ContributionTypedData {
+    type Error = Eip712Error;
+
+    fn domain(&self) -> Result<EIP712Domain, Self::Error> {
+        TypedData::from(self.clone()).domain()
+    }
+
+    fn type_hash() -> Result<[u8; 32], Self::Error> {
+        TypedData::type_hash()
+    }
+
+    fn struct_hash(&self) -> Result<[u8; 32], Self::Error> {
+        TypedData::from(self.clone()).struct_hash()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_thing() {
+        println!("foo");
+    }
 }

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -9,7 +9,10 @@ use crate::{
     signature::identity::Identity,
     BatchContribution, Engine, Tau, G1, G2,
 };
-use ethers::types::transaction::eip712::{EIP712Domain, Eip712, Eip712Error, TypedData};
+use ethers_core::types::{
+    transaction::eip712::{EIP712Domain, Eip712, Eip712Error, TypedData},
+    Signature as EthSignature,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
 
@@ -61,7 +64,7 @@ impl<'de> Deserialize<'de> for BlsSignature {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct EcdsaSignature(pub Option<ethers::types::Signature>);
+pub struct EcdsaSignature(pub Option<EthSignature>);
 
 impl EcdsaSignature {
     #[must_use]
@@ -104,8 +107,7 @@ impl<'de> Deserialize<'de> for EcdsaSignature {
     {
         optional_hex_to_bytes::<_, 65>(deserializer).map(|bytes_opt| {
             Self(bytes_opt.map(|bytes| {
-                ethers::types::Signature::try_from(&bytes[..])
-                    .expect("Impossible, input is guaranteed correct")
+                EthSignature::try_from(&bytes[..]).expect("Impossible, input is guaranteed correct")
             }))
         })
     }

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -208,15 +208,15 @@ mod tests {
             let mut tmp = vec![G2::one(), G2::one()];
             Arkworks::add_tau_g2(&tau, &mut tmp).unwrap();
             let pubkey = tmp[1];
-            let recovered = signed.prune::<BLST>(&bytes, pubkey);
+            let recovered = signed.prune::<BLST>(bytes, pubkey);
             assert_eq!(signed, recovered);
-        })
+        });
     }
 
     #[test]
     fn test_bls_prune_wrong_msg() {
-        let message = "git|1234|foobar".as_bytes();
-        let wrong_msg = "git|4567|bazbaz".as_bytes();
+        let message = b"git|1234|foobar";
+        let wrong_msg = b"git|4567|bazbaz";
         let tau = Secret::new(F::one());
         let signed = BlsSignature::sign::<BLST>(message, &tau);
         assert!(signed.0.is_some());
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_bls_prune_wrong_sig() {
-        let message = "git|1234|foobar".as_bytes();
+        let message = b"git|1234|foobar";
         let tau = Arkworks::generate_tau(&Entropy::new(thread_rng().gen()));
         let wrong_tau = Arkworks::generate_tau(&Entropy::new(thread_rng().gen()));
         let signed = BlsSignature::sign::<BLST>(message, &tau);

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -2,6 +2,7 @@ use super::{CeremonyError, Contribution, Powers, G1, G2};
 use crate::engine::Engine;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
+use crate::signature::BlsSignature;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Transcript {
@@ -55,8 +56,9 @@ impl Transcript {
     #[must_use]
     pub fn contribution(&self) -> Contribution {
         Contribution {
-            powers:     self.powers.clone(),
-            pot_pubkey: G2::one(),
+            powers:        self.powers.clone(),
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
         }
     }
 

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -113,6 +113,7 @@ impl Transcript {
     pub fn add(&mut self, contribution: Contribution) {
         self.witness.products.push(contribution.powers.g1[1]);
         self.witness.pubkeys.push(contribution.pot_pubkey);
+        self.witness.signatures.push(contribution.bls_signature);
         self.powers = contribution.powers;
     }
 }
@@ -140,7 +141,7 @@ mod test {
                 "G2Powers": [
                 "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
                 "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
-                ]
+                ],
             },
             "witness": {
                 "runningProducts": [
@@ -148,7 +149,8 @@ mod test {
                 ],
                 "potPubkeys": [
                     "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
-                ]
+                ],
+                "blsSignatures": [""],
             }
             })
         );

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -1,8 +1,7 @@
 use super::{CeremonyError, Contribution, Powers, G1, G2};
-use crate::engine::Engine;
+use crate::{engine::Engine, signature::BlsSignature};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use crate::signature::BlsSignature;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Transcript {
@@ -19,6 +18,9 @@ pub struct Witness {
 
     #[serde(rename = "potPubkeys")]
     pub pubkeys: Vec<G2>,
+
+    #[serde(rename = "blsSignatures")]
+    pub signatures: Vec<BlsSignature>,
 }
 
 impl Transcript {
@@ -46,8 +48,9 @@ impl Transcript {
         Self {
             powers:  Powers::new(num_g1, num_g2),
             witness: Witness {
-                products: vec![G1::one()],
-                pubkeys:  vec![G2::one()],
+                products:   vec![G1::one()],
+                pubkeys:    vec![G2::one()],
+                signatures: vec![BlsSignature::empty()],
             },
         }
     }

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -448,6 +448,7 @@ async fn post_authenticate(
     let session_id = {
         let mut state = auth_state.write().await;
 
+        #[allow(clippy::option_if_let_else)]
         if let Some(session_id) = state.unique_id_session.get(&user_data.unique_id()) {
             session_id.clone()
         } else {

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -346,7 +346,7 @@ pub async fn github_callback(
 
 #[derive(Debug, Deserialize)]
 struct EthUserInfo {
-    sub:                String,
+    sub: String,
 }
 
 // This endpoint allows one to consume an oAUTH authorisation code

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -88,14 +88,14 @@ pub async fn contribute(
     if let Err(e) = result {
         lobby_state.clear_current_contributor().await;
         storage
-            .expire_contribution(id_token.unique_identifier())
+            .expire_contribution(&id_token.unique_identifier())
             .await?;
         return Err(e);
     }
 
     let receipt = Receipt {
-        id_token,
-        witness: contribution.receipt(),
+        identity: id_token.identity,
+        witness:  contribution.receipt(),
     };
 
     let (signed_msg, signature) = receipt

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -81,7 +81,7 @@ pub async fn contribute(
     let result = {
         let mut transcript = shared_transcript.write().await;
         transcript
-            .verify_add::<Engine>(contribution.clone())
+            .verify_add::<Engine>(contribution.clone(), id_token.identity.clone())
             .map_err(ContributeError::InvalidContribution)
     };
 
@@ -154,7 +154,7 @@ mod tests {
     };
     use axum::{Extension, Json};
     use clap::Parser;
-    use kzg_ceremony_crypto::BatchTranscript;
+    use kzg_ceremony_crypto::{signature::identity::Identity, BatchTranscript};
     use std::{
         sync::{atomic::AtomicUsize, Arc},
         time::Duration,
@@ -231,7 +231,10 @@ mod tests {
         let transcript_1 = {
             let mut transcript = transcript.clone();
             transcript
-                .verify_add::<Engine>(contribution_1.clone())
+                .verify_add::<Engine>(contribution_1.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };
@@ -239,7 +242,10 @@ mod tests {
         let transcript_2 = {
             let mut transcript = transcript_1.clone();
             transcript
-                .verify_add::<Engine>(contribution_2.clone())
+                .verify_add::<Engine>(contribution_2.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -70,7 +70,7 @@ pub async fn try_contribute(
             }
             info.is_first_ping_attempt = false;
             info.last_ping_time = now;
-            Ok(info.token.unique_identifier().to_owned())
+            Ok(info.token.unique_identifier())
         })
         .await
         .unwrap_or(Err(TryContributeError::UnknownSessionId))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,9 @@ async fn hello_world() -> Html<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kzg_ceremony_crypto::{BatchContribution, BatchTranscript, G2};
+    use kzg_ceremony_crypto::{
+        signature::identity::Identity, BatchContribution, BatchTranscript, G2,
+    };
     use secrecy::Secret;
 
     pub fn test_transcript() -> BatchTranscript {
@@ -191,7 +193,9 @@ mod tests {
     pub fn valid_contribution(transcript: &BatchTranscript, no: u8) -> BatchContribution {
         let entropy = Secret::new([no; 32]);
         let mut contribution = transcript.contribution();
-        contribution.add_entropy::<Engine>(&entropy).unwrap();
+        contribution
+            .add_entropy::<Engine>(&entropy, &Identity::None)
+            .unwrap();
         contribution
     }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1,15 +1,14 @@
 use crate::{
     keys::{Keys, Signature, SignatureError},
-    sessions::IdToken,
 };
-use kzg_ceremony_crypto::G2;
+use kzg_ceremony_crypto::{signature::identity::Identity, G2};
 use serde::Serialize;
 
 // Receipt for contributor that sequencer has
 // included their contribution
 #[derive(Serialize)]
 pub struct Receipt {
-    pub(crate) id_token: IdToken,
+    pub(crate) identity: Identity,
     pub witness:         Vec<G2>,
 }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1,6 +1,4 @@
-use crate::{
-    keys::{Keys, Signature, SignatureError},
-};
+use crate::keys::{Keys, Signature, SignatureError};
 use kzg_ceremony_crypto::{signature::identity::Identity, G2};
 use serde::Serialize;
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -4,7 +4,6 @@ use axum::{
     TypedHeader,
 };
 use headers::{authorization::Bearer, Authorization};
-use http::StatusCode;
 use kzg_ceremony_crypto::{signature::identity::Identity, ErrorCode};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use headers::{authorization::Bearer, Authorization};
 use http::StatusCode;
+use kzg_ceremony_crypto::signature::identity::Identity;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fmt::{Display, Formatter};
@@ -54,13 +55,9 @@ impl IntoResponse for SessionError {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct IdToken {
-    pub sub:      String,
-    pub nickname: String,
-    // The provider whom the client used to login with
-    // Example, Google, Ethereum, Facebook
-    pub provider: String,
+    pub identity: Identity,
     pub exp:      u64,
 }
 
@@ -69,8 +66,8 @@ impl IdToken {
     // For example, see: https://developers.google.com/identity/protocols/oauth2/openid-connect#obtainuserinfo
     // We can use this to identify when a user signs in with the same
     // login and signup
-    pub fn unique_identifier(&self) -> &str {
-        &self.sub
+    pub fn unique_identifier(&self) -> String {
+        self.identity.unique_id()
     }
 }
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -5,15 +5,16 @@ use crate::{
     Options,
 };
 use clap::Parser;
+use kzg_ceremony_crypto::signature::identity::Identity;
 use tokio::time::Instant;
-use uuid::Uuid;
 
 #[must_use]
 pub fn test_jwt(exp: u64) -> IdToken {
     IdToken {
-        sub: Uuid::new_v4().to_string(),
-        nickname: String::from("foo"),
-        provider: String::from("foo"),
+        identity: Identity::Github {
+            id:       1234,
+            username: "test_user".to_string(),
+        },
         exp,
     }
 }

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -109,7 +109,7 @@ pub async fn extract_session_id_from_auth_response(response: reqwest::Response) 
 
 pub async fn login(harness: &Harness, http_client: &reqwest::Client, user: &TestUser) -> String {
     let csrf = get_and_validate_csrf_token(harness, None).await;
-    let callback_result = request_auth_callback(harness, http_client, &user, &csrf).await;
+    let callback_result = request_auth_callback(harness, http_client, user, &csrf).await;
     assert_eq!(callback_result.status(), StatusCode::OK);
     extract_session_id_from_auth_response(callback_result).await
 }

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -260,7 +260,8 @@ pub async fn contribute_successfully(
 pub fn assert_includes_contribution(
     transcript: &BatchTranscript,
     contribution: &BatchContribution,
-    user_id: &str,
+    user: &TestUser,
+    expect_ecdsa_signed: bool,
 ) {
     let first_contrib_pubkey = contribution.contributions[0].pot_pubkey;
     let index_in_transcripts = transcript.transcripts[0]
@@ -271,8 +272,16 @@ pub fn assert_includes_contribution(
         .expect("Transcript does not include contribution.");
     assert_eq!(
         transcript.participant_ids[index_in_transcripts].to_string(),
-        user_id
+        user.identity()
     );
+
+    match &transcript.participant_ecdsa_signatures[index_in_transcripts].0 {
+        Some(_) if !expect_ecdsa_signed => {
+            panic!("Expected no signature, but signature is present")
+        }
+        None if expect_ecdsa_signed => panic!("Expected a signature, but none found"),
+        _ => (),
+    }
 
     transcript
         .transcripts

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -1,0 +1,285 @@
+use crate::{
+    common::mock_auth_service::{AnyTestUser, TestUser},
+    Address, Harness,
+};
+use ethers_core::types::Signature;
+use http::StatusCode;
+use kzg_ceremony_crypto::{BatchContribution, BatchTranscript, G2};
+use secrecy::Secret;
+use serde_json::Value;
+use std::collections::HashMap;
+use url::Url;
+
+/// This function acts both as a test and a utility. This way, we'll test the
+/// behavior in a variety of different app states.
+pub async fn get_and_validate_csrf_token(harness: &Harness, redirect_url: Option<&str>) -> String {
+    let client = reqwest::Client::new();
+
+    let mut url = harness.app_path("auth/request_link");
+    redirect_url.into_iter().for_each(|redirect| {
+        url.query_pairs_mut().append_pair("redirect_to", redirect);
+    });
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+
+    let csrf_for_gh = Url::parse(
+        response
+            .get("github_auth_url")
+            .expect("/auth/request_link response must contain a github_auth_url")
+            .as_str()
+            .expect("github_auth_url must be a string"),
+    )
+    .expect("github_auth_url must be a valid Url")
+    .query_pairs()
+    .into_owned()
+    .collect::<HashMap<_, _>>()
+    .remove("state")
+    .expect("github_auth_url must contain an url-encoded CSRF token");
+
+    let csrf_for_eth = Url::parse(
+        response
+            .get("eth_auth_url")
+            .expect("/auth/request_link response must contain an eth_auth_url")
+            .as_str()
+            .expect("eth_auth_url must be a string"),
+    )
+    .expect("eth_auth_url must be a valid Url")
+    .query_pairs()
+    .into_owned()
+    .collect::<HashMap<_, _>>()
+    .remove("state")
+    .expect("eth_auth_url must contain an url-encoded CSRF token");
+
+    assert_eq!(
+        csrf_for_eth, csrf_for_gh,
+        "CSRF tokens must be the same for all providers but got {} and {}",
+        csrf_for_eth, csrf_for_gh
+    );
+
+    csrf_for_eth
+}
+
+pub fn entropy_from_str(seed: &str) -> Secret<[u8; 32]> {
+    let padding = "padding".repeat(5);
+    let entropy = format!("{seed}{padding}")
+        .bytes()
+        .take(32)
+        .collect::<Vec<u8>>()
+        .try_into()
+        .unwrap();
+    Secret::new(entropy)
+}
+
+pub async fn request_auth_callback(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    user: &TestUser,
+    csrf: &str,
+) -> reqwest::Response {
+    let url_ext = match user.user {
+        AnyTestUser::Eth(_) => "auth/callback/eth",
+        AnyTestUser::Gh(_) => "auth/callback/github",
+    };
+    http_client
+        .get(harness.options.server.join(url_ext).unwrap())
+        .query(&[("state", csrf), ("code", &user.id.to_string())])
+        .send()
+        .await
+        .expect("Could not call the endpoint")
+}
+
+pub async fn extract_session_id_from_auth_response(response: reqwest::Response) -> String {
+    response
+        .json::<Value>()
+        .await
+        .expect("Response must be valid JSON.")
+        .get("session_id")
+        .expect("Response must contain session_id")
+        .as_str()
+        .expect("session_id must be a string")
+        .to_string()
+}
+
+pub async fn login(harness: &Harness, http_client: &reqwest::Client, user: &TestUser) -> String {
+    let csrf = get_and_validate_csrf_token(harness, None).await;
+    let callback_result = request_auth_callback(harness, http_client, &user, &csrf).await;
+    assert_eq!(callback_result.status(), StatusCode::OK);
+    extract_session_id_from_auth_response(callback_result).await
+}
+
+pub async fn create_and_login_gh_user(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    name: String,
+) -> (TestUser, String) {
+    let user = harness.create_gh_user(name.clone()).await;
+    let session_id = login(harness, http_client, &user).await;
+    (user, session_id)
+}
+
+pub async fn request_try_contribute(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    session_id: &str,
+) -> reqwest::Response {
+    http_client
+        .post(harness.options.server.join("lobby/try_contribute").unwrap())
+        .header("Authorization", format!("Bearer {session_id}"))
+        .send()
+        .await
+        .unwrap()
+}
+
+pub async fn try_contribute(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    session_id: &str,
+) -> BatchContribution {
+    let response = request_try_contribute(harness, http_client, session_id).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Response must be successful"
+    );
+
+    response
+        .json::<BatchContribution>()
+        .await
+        .expect("Successful response must be a contribution")
+}
+
+pub async fn request_contribute(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    session_id: &str,
+    contribution: &BatchContribution,
+) -> reqwest::Response {
+    http_client
+        .post(harness.options.server.join("contribute").unwrap())
+        .header("Authorization", format!("Bearer {session_id}"))
+        .json(contribution)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn get_sequencer_eth_address(harness: &Harness, http_client: &reqwest::Client) -> String {
+    http_client
+        .get(harness.app_path("/info/status"))
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap()
+        .get("sequencer_address")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+pub async fn contribute_successfully(
+    harness: &Harness,
+    http_client: &reqwest::Client,
+    session_id: &str,
+    contribution: &BatchContribution,
+    user_id: &str,
+) {
+    let response = request_contribute(harness, http_client, session_id, contribution).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Response must be successful"
+    );
+
+    let response_json = response
+        .json::<Value>()
+        .await
+        .expect("Must return valid JSON");
+
+    let receipt = response_json
+        .get("receipt")
+        .expect("must contain the receipt field")
+        .as_str()
+        .expect("receipt field must be a string");
+
+    let signature: Signature = response_json
+        .get("signature")
+        .expect("must contain signature")
+        .as_str()
+        .expect("signature must be a string")
+        .parse()
+        .expect("must be a valid signature");
+
+    let address: Address = get_sequencer_eth_address(harness, http_client)
+        .await
+        .parse()
+        .unwrap();
+
+    signature
+        .verify(receipt, address)
+        .expect("must be valid signature");
+
+    let receipt_contents =
+        serde_json::from_str::<Value>(receipt).expect("receipt must be a JSON-encoded string");
+    assert_eq!(
+        receipt_contents
+            .get("identity")
+            .expect("must contain identity"),
+        user_id
+    );
+
+    let witness: Vec<G2> = serde_json::from_value(
+        receipt_contents
+            .get("witness")
+            .expect("must contain witness")
+            .clone(),
+    )
+    .expect("witness must be a vector of G2 points");
+
+    assert_eq!(
+        witness,
+        contribution
+            .contributions
+            .iter()
+            .map(|c| c.pot_pubkey)
+            .collect::<Vec<_>>()
+    )
+}
+
+pub fn assert_includes_contribution(
+    transcript: &BatchTranscript,
+    contribution: &BatchContribution,
+    user_id: &str,
+) {
+    let first_contrib_pubkey = contribution.contributions[0].pot_pubkey;
+    let index_in_transcripts = transcript.transcripts[0]
+        .witness
+        .pubkeys
+        .iter()
+        .position(|pk| pk == &first_contrib_pubkey)
+        .expect("Transcript does not include contribution.");
+    assert_eq!(
+        transcript.participant_ids[index_in_transcripts].to_string(),
+        user_id
+    );
+
+    transcript
+        .transcripts
+        .iter()
+        .zip(contribution.contributions.iter())
+        .for_each(|(t, c)| {
+            assert_eq!(t.witness.products[index_in_transcripts], c.powers.g1[1]);
+            assert_eq!(t.witness.pubkeys[index_in_transcripts], c.pot_pubkey);
+        })
+}

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use crate::common::{
     mock_auth_service,
     mock_auth_service::{AuthState, GhUser, TestUser},
@@ -6,7 +5,7 @@ use crate::common::{
 use clap::Parser;
 use kzg_ceremony_crypto::BatchTranscript;
 use kzg_ceremony_sequencer::{io::read_json_file, start_server, Options};
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 use tempfile::{tempdir, TempDir};
 use tokio::sync::{broadcast, oneshot, Mutex, MutexGuard, OnceCell};
 use url::Url;

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use crate::common::{
     mock_auth_service,
     mock_auth_service::{AuthState, GhUser, TestUser},
@@ -173,6 +174,12 @@ impl Builder {
 
     pub fn allow_multi_contribution(mut self) -> Self {
         self.options.multi_contribution = true;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn set_transcript_file(mut self, path: PathBuf) -> Self {
+        self.options.transcript_file = path;
         self
     }
 

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     mock_auth_service,
-    mock_auth_service::{AuthState, GhUser},
+    mock_auth_service::{AuthState, GhUser, TestUser},
 };
 use clap::Parser;
 use kzg_ceremony_crypto::BatchTranscript;
@@ -25,8 +25,12 @@ fn test_options() -> Options {
         "INVALID",
         "--gh-client-id",
         "INVALID",
+        "--eth-token-url",
+        "http://127.0.0.1:3001/eth/oauth/token",
+        "--eth-userinfo-url",
+        "http://127.0.0.1:3001/eth/user",
         "--eth-rpc-url",
-        "INVALID",
+        "http://127.0.0.1:3001/eth/rpc",
         "--eth-client-secret",
         "INVALID",
         "--eth-client-id",
@@ -54,13 +58,17 @@ impl Harness {
         read_json_file(self.options.transcript_file.clone()).await
     }
 
-    pub async fn create_valid_user(&self, name: String) -> u64 {
+    pub async fn create_gh_user(&self, name: String) -> TestUser {
         self.auth_state
-            .register_user(GhUser {
+            .register_gh_user(GhUser {
                 created_at: "2022-01-01T00:00:00Z".to_string(),
                 name,
             })
             .await
+    }
+
+    pub async fn create_eth_user(&self) -> TestUser {
+        self.auth_state.register_eth_user().await
     }
 
     pub fn app_path(&self, path: &str) -> Url {

--- a/tests/common/mock_auth_service.rs
+++ b/tests/common/mock_auth_service.rs
@@ -2,9 +2,11 @@ use axum::{
     routing::{get, post, IntoMakeService},
     Extension, Form, Json, Router, TypedHeader,
 };
+use ethers_signers::{LocalWallet, Signer};
 use headers::{authorization::Bearer, Authorization};
 use http::StatusCode;
 use hyper::{server::conn::AddrIncoming, Server};
+use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
@@ -19,21 +21,13 @@ pub fn start_server(auth_state: AuthState) -> Server<AddrIncoming, IntoMakeServi
     let app = Router::new()
         .route("/github/oauth/token", post(exchange_gh_token))
         .route("/github/user", get(gh_userinfo))
+        .route("/eth/oauth/token", post(exchange_eth_token))
+        .route("/eth/user", get(eth_userinfo))
+        .route("/eth/rpc", post(eth_rpc))
         .layer(Extension(auth_state));
     Server::try_bind(&SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 3001))
         .unwrap()
         .serve(app.into_make_service())
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct GhUser {
-    pub name:       String,
-    pub created_at: String,
-}
-
-#[derive(Clone, Default)]
-pub struct AuthState {
-    github_users: Arc<RwLock<GhUsersState>>,
 }
 
 #[derive(Default)]
@@ -51,13 +45,83 @@ impl GhUsersState {
     }
 }
 
+#[derive(Default)]
+struct EthUsersState {
+    users:   HashMap<u64, LocalWallet>,
+    next_id: u64,
+}
+
+impl EthUsersState {
+    fn register(&mut self) -> (u64, LocalWallet) {
+        let id = self.next_id;
+        self.next_id += 1;
+        let wallet = LocalWallet::new(&mut thread_rng());
+        self.users.insert(id, wallet.clone());
+        (id, wallet)
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct GhUser {
+    pub name:       String,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug)]
+pub enum AnyTestUser {
+    Eth(LocalWallet),
+    Gh(GhUser),
+}
+
+#[derive(Clone, Debug)]
+pub struct TestUser {
+    pub id:   u64,
+    pub user: AnyTestUser,
+}
+
+impl TestUser {
+    pub fn identity(&self) -> String {
+        match &self.user {
+            AnyTestUser::Eth(wallet) => format!("eth|0x{}", hex::encode(wallet.address().0)),
+            AnyTestUser::Gh(user) => format!("git|{}|{}", self.id, user.name),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AuthState {
+    github_users: Arc<RwLock<GhUsersState>>,
+    eth_users:    Arc<RwLock<EthUsersState>>,
+}
+
 impl AuthState {
-    pub async fn register_user(&self, user: GhUser) -> u64 {
-        self.github_users.write().await.register(user)
+    pub async fn register_gh_user(&self, user: GhUser) -> TestUser {
+        let id = self.github_users.write().await.register(user.clone());
+        TestUser {
+            id,
+            user: AnyTestUser::Gh(user),
+        }
     }
 
-    pub async fn get_user(&self, auth_code: u64) -> Option<GhUser> {
+    pub async fn register_eth_user(&self) -> TestUser {
+        let (id, wallet) = self.eth_users.write().await.register();
+        TestUser {
+            id,
+            user: AnyTestUser::Eth(wallet),
+        }
+    }
+
+    pub async fn get_gh_user(&self, auth_code: u64) -> Option<GhUser> {
         self.github_users
+            .read()
+            .await
+            .users
+            .get(&auth_code)
+            .map(Clone::clone)
+    }
+
+    pub async fn get_eth_user(&self, auth_code: u64) -> Option<LocalWallet> {
+        self.eth_users
             .read()
             .await
             .users
@@ -75,7 +139,29 @@ async fn exchange_gh_token(
     Form(req): Form<ExchangeRequest>,
     Extension(state): Extension<AuthState>,
 ) -> (StatusCode, Json<Value>) {
-    let user = state.get_user(req.code).await;
+    let user = state.get_gh_user(req.code).await;
+    match user {
+        Some(_) => (
+            StatusCode::OK,
+            Json(json!({
+                "access_token": format!("token_of::{}", req.code),
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+                "expires_in": 60
+            })),
+        ),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "Invalid code"})),
+        ),
+    }
+}
+
+async fn exchange_eth_token(
+    Form(req): Form<ExchangeRequest>,
+    Extension(state): Extension<AuthState>,
+) -> (StatusCode, Json<Value>) {
+    let user = state.get_eth_user(req.code).await;
     match user {
         Some(_) => (
             StatusCode::OK,
@@ -104,7 +190,7 @@ async fn gh_userinfo(
         .get(1)
         .expect("invalid auth token");
     let code = u64::from_str(code_str).expect("invalid auth token");
-    let user = state.get_user(code).await;
+    let user = state.get_gh_user(code).await;
     match user {
         Some(user) => (
             StatusCode::OK,
@@ -115,4 +201,36 @@ async fn gh_userinfo(
             Json(json!({"error": "Invalid auth token"})),
         ),
     }
+}
+
+async fn eth_userinfo(
+    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    Extension(state): Extension<AuthState>,
+) -> (StatusCode, Json<Value>) {
+    let token = auth.0.token();
+    let code_str = *token
+        .split("::")
+        .collect::<Vec<_>>()
+        .get(1)
+        .expect("invalid auth token");
+    let code = u64::from_str(code_str).expect("invalid auth token");
+    let user = state.get_eth_user(code).await;
+    match user {
+        Some(user) => (
+            StatusCode::OK,
+            Json(json!({
+                "sub": format!("eip155:1:0x{}", hex::encode(user.address().0))
+            })),
+        ),
+        None => (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid auth token"})),
+        ),
+    }
+}
+
+async fn eth_rpc() -> (StatusCode, Json<Value>) {
+    // ignore the request and just let it through, assuming we're asking for
+    // nonce and returning a number large enough to pass validation
+    (StatusCode::OK, Json(json!({"result": "0x1F"})))
 }

--- a/tests/common/mock_auth_service.rs
+++ b/tests/common/mock_auth_service.rs
@@ -6,6 +6,7 @@ use ethers_signers::{LocalWallet, Signer};
 use headers::{authorization::Bearer, Authorization};
 use http::StatusCode;
 use hyper::{server::conn::AddrIncoming, Server};
+use kzg_ceremony_crypto::signature::identity::Identity;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -80,10 +81,14 @@ pub struct TestUser {
 }
 
 impl TestUser {
-    pub fn identity(&self) -> String {
+    pub fn identity(&self) -> Identity {
         match &self.user {
-            AnyTestUser::Eth(wallet) => format!("eth|0x{}", hex::encode(wallet.address().0)),
-            AnyTestUser::Gh(user) => format!("git|{}|{}", self.id, user.name),
+            AnyTestUser::Eth(wallet) => {
+                Identity::from_str(&format!("eth|0x{}", hex::encode(wallet.address().0))).unwrap()
+            }
+            AnyTestUser::Gh(user) => {
+                Identity::from_str(&format!("git|{}|{}", self.id, user.name)).unwrap()
+            }
         }
     }
 

--- a/tests/common/mock_auth_service.rs
+++ b/tests/common/mock_auth_service.rs
@@ -86,6 +86,13 @@ impl TestUser {
             AnyTestUser::Gh(user) => format!("git|{}|{}", self.id, user.name),
         }
     }
+
+    pub fn is_eth(&self) -> bool {
+        match &self.user {
+            AnyTestUser::Eth(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Default)]

--- a/tests/common/mock_auth_service.rs
+++ b/tests/common/mock_auth_service.rs
@@ -93,10 +93,7 @@ impl TestUser {
     }
 
     pub fn is_eth(&self) -> bool {
-        match &self.user {
-            AnyTestUser::Eth(_) => true,
-            _ => false,
-        }
+        matches!(&self.user, AnyTestUser::Eth(_))
     }
 }
 

--- a/tests/common/mock_auth_service.rs
+++ b/tests/common/mock_auth_service.rs
@@ -108,7 +108,7 @@ async fn gh_userinfo(
     match user {
         Some(user) => (
             StatusCode::OK,
-            Json(json!({"login": user.name, "created_at": user.created_at})),
+            Json(json!({"login": user.name, "created_at": user.created_at, "id": code})),
         ),
         None => (
             StatusCode::UNAUTHORIZED,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod harness;
 pub mod mock_auth_service;
+pub mod actions;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
+pub mod actions;
 pub mod harness;
 pub mod mock_auth_service;
-pub mod actions;
 pub mod participants;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod harness;
 pub mod mock_auth_service;
 pub mod actions;
+pub mod participants;

--- a/tests/common/participants.rs
+++ b/tests/common/participants.rs
@@ -1,20 +1,20 @@
-use crate::{actions, AnyTestUser, Harness, TestUser};
+use crate::{actions, actions::entropy_from_str, AnyTestUser, Harness, TestUser};
+use ethers_core::types::Signature;
 use ethers_signers::Signer;
 use http::StatusCode;
 use kzg_ceremony_crypto::{
     signature, signature::EcdsaSignature, Arkworks, BatchContribution, BatchTranscript,
 };
-use secrecy::Secret;
+use rand::{thread_rng, Rng};
 
 type PostConditionCheck = Box<dyn FnOnce(&BatchTranscript) -> () + Send + Sync>;
 
-pub async fn well_behaved(
+async fn await_contribution_slot(
     harness: &Harness,
     client: &reqwest::Client,
-    user: TestUser,
-) -> PostConditionCheck {
-    let session_id = actions::login(harness, client, &user).await;
-    let mut contribution = loop {
+    session_id: &str,
+) -> BatchContribution {
+    loop {
         let try_contribute_response =
             actions::request_try_contribute(harness, client, &session_id).await;
         assert_eq!(try_contribute_response.status(), StatusCode::OK);
@@ -23,7 +23,7 @@ pub async fn well_behaved(
             .await
             .ok();
         if let Some(contrib) = maybe_contribution {
-            break contrib;
+            return contrib;
         }
 
         tokio::time::sleep(
@@ -31,17 +31,18 @@ pub async fn well_behaved(
                 - harness.options.lobby.lobby_checkin_tolerance,
         )
         .await;
-    };
+    }
+}
 
-    let entropy = format!("{} such an unguessable string, wow!", user.identity())
-        .bytes()
-        .take(32)
-        .collect::<Vec<u8>>()
-        .try_into()
-        .unwrap();
-    let entropy = Secret::new(entropy);
+pub async fn well_behaved(
+    harness: &Harness,
+    client: &reqwest::Client,
+    user: TestUser,
+) -> PostConditionCheck {
+    let session_id = actions::login(harness, client, &user).await;
+    let mut contribution = await_contribution_slot(harness, client, &session_id).await;
     contribution
-        .add_entropy::<Arkworks>(&entropy)
+        .add_entropy::<Arkworks>(&entropy_from_str(&user.identity()))
         .expect("Adding entropy must be possible");
 
     if let AnyTestUser::Eth(wallet) = &user.user {
@@ -67,45 +68,50 @@ pub async fn well_behaved(
     })
 }
 
+pub async fn wrong_ecdsa(
+    harness: &Harness,
+    client: &reqwest::Client,
+    user: TestUser,
+) -> PostConditionCheck {
+    let session_id = actions::login(harness, client, &user).await;
+    let mut contribution = await_contribution_slot(harness, client, &session_id).await;
+    contribution
+        .add_entropy::<Arkworks>(&entropy_from_str(&user.identity()))
+        .expect("Adding entropy must be possible");
+
+    let mut random_bytes = [0 as u8; 65];
+    (0..65).for_each(|i| {
+        random_bytes[i] = thread_rng().gen();
+    });
+
+    contribution.ecdsa_signature =
+        EcdsaSignature(Some(Signature::try_from(&random_bytes[..]).unwrap()));
+
+    actions::contribute_successfully(
+        harness,
+        client,
+        &session_id,
+        &contribution,
+        &user.identity(),
+    )
+    .await;
+
+    Box::new(move |transcript| {
+        actions::assert_includes_contribution(transcript, &contribution, &user, false);
+    })
+}
+
 pub async fn slow_compute(
     harness: &Harness,
     client: &reqwest::Client,
     user: TestUser,
 ) -> PostConditionCheck {
     let session_id = actions::login(harness, client, &user).await;
-    let mut contribution = loop {
-        let try_contribute_response =
-            actions::request_try_contribute(harness, client, &session_id).await;
-        assert_eq!(try_contribute_response.status(), StatusCode::OK);
-        let maybe_contribution = try_contribute_response
-            .json::<BatchContribution>()
-            .await
-            .ok();
-        if let Some(contrib) = maybe_contribution {
-            break contrib;
-        }
-
-        tokio::time::sleep(
-            harness.options.lobby.lobby_checkin_frequency
-                - harness.options.lobby.lobby_checkin_tolerance,
-        )
-        .await;
-    };
-
-    let entropy = format!("{} such an unguessable string, wow!", user.identity())
-        .bytes()
-        .take(32)
-        .collect::<Vec<u8>>()
-        .try_into()
-        .unwrap();
-    let entropy = Secret::new(entropy);
-
+    let mut contribution = await_contribution_slot(harness, client, &session_id).await;
     tokio::time::sleep(harness.options.lobby.compute_deadline).await;
-
     contribution
-        .add_entropy::<Arkworks>(&entropy)
+        .add_entropy::<Arkworks>(&entropy_from_str(&user.identity()))
         .expect("Adding entropy must be possible");
-
     let response = actions::request_contribute(harness, client, &session_id, &contribution).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     Box::new(|_| {})

--- a/tests/common/participants.rs
+++ b/tests/common/participants.rs
@@ -1,0 +1,99 @@
+use crate::{actions, Harness, TestUser};
+use http::StatusCode;
+use kzg_ceremony_crypto::{Arkworks, BatchContribution, BatchTranscript};
+use secrecy::Secret;
+
+type PostConditionCheck = Box<dyn FnOnce(&BatchTranscript) -> () + Send + Sync>;
+
+pub async fn well_behaved(
+    harness: &Harness,
+    client: &reqwest::Client,
+    user: TestUser,
+) -> PostConditionCheck {
+    let session_id = actions::login(harness, client, &user).await;
+    let mut contribution = loop {
+        let try_contribute_response =
+            actions::request_try_contribute(harness, client, &session_id).await;
+        assert_eq!(try_contribute_response.status(), StatusCode::OK);
+        let maybe_contribution = try_contribute_response
+            .json::<BatchContribution>()
+            .await
+            .ok();
+        if let Some(contrib) = maybe_contribution {
+            break contrib;
+        }
+
+        tokio::time::sleep(
+            harness.options.lobby.lobby_checkin_frequency
+                - harness.options.lobby.lobby_checkin_tolerance,
+        )
+        .await;
+    };
+
+    let entropy = format!("{} such an unguessable string, wow!", user.identity())
+        .bytes()
+        .take(32)
+        .collect::<Vec<u8>>()
+        .try_into()
+        .unwrap();
+    let entropy = Secret::new(entropy);
+    contribution
+        .add_entropy::<Arkworks>(&entropy)
+        .expect("Adding entropy must be possible");
+    actions::contribute_successfully(
+        harness,
+        client,
+        &session_id,
+        &contribution,
+        &user.identity(),
+    )
+    .await;
+
+    Box::new(move |transcript| {
+        actions::assert_includes_contribution(transcript, &contribution, &user.identity());
+    })
+}
+
+pub async fn slow_compute(
+    harness: &Harness,
+    client: &reqwest::Client,
+    user: TestUser,
+) -> PostConditionCheck {
+    let session_id = actions::login(harness, client, &user).await;
+    let mut contribution = loop {
+        let try_contribute_response =
+            actions::request_try_contribute(harness, client, &session_id).await;
+        assert_eq!(try_contribute_response.status(), StatusCode::OK);
+        let maybe_contribution = try_contribute_response
+            .json::<BatchContribution>()
+            .await
+            .ok();
+        if let Some(contrib) = maybe_contribution {
+            break contrib;
+        }
+
+        tokio::time::sleep(
+            harness.options.lobby.lobby_checkin_frequency
+                - harness.options.lobby.lobby_checkin_tolerance,
+        )
+        .await;
+    };
+
+    let entropy = format!("{} such an unguessable string, wow!", user.identity())
+        .bytes()
+        .take(32)
+        .collect::<Vec<u8>>()
+        .try_into()
+        .unwrap();
+    let entropy = Secret::new(entropy);
+
+    tokio::time::sleep(harness.options.lobby.compute_deadline).await;
+
+    contribution
+        .add_entropy::<Arkworks>(&entropy)
+        .expect("Adding entropy must be possible");
+
+    let response = actions::request_contribute(harness, client, &session_id, &contribution).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    Box::new(|_| {})
+}

--- a/tests/common/participants.rs
+++ b/tests/common/participants.rs
@@ -9,7 +9,7 @@ use kzg_ceremony_crypto::{
 };
 use rand::{thread_rng, Rng};
 
-type PostConditionCheck = Box<dyn FnOnce(&BatchTranscript) -> () + Send + Sync>;
+type PostConditionCheck = Box<dyn FnOnce(&BatchTranscript) + Send + Sync>;
 
 async fn await_contribution_slot(
     harness: &Harness,
@@ -18,7 +18,7 @@ async fn await_contribution_slot(
 ) -> BatchContribution {
     loop {
         let try_contribute_response =
-            actions::request_try_contribute(harness, client, &session_id).await;
+            actions::request_try_contribute(harness, client, session_id).await;
         assert_eq!(try_contribute_response.status(), StatusCode::OK);
         let maybe_contribution = try_contribute_response
             .json::<BatchContribution>()
@@ -93,7 +93,7 @@ pub async fn wrong_ecdsa(
         )
         .expect("Adding entropy must be possible");
 
-    let mut random_bytes = [0 as u8; 65];
+    let mut random_bytes = [0; 65];
     (0..65).for_each(|i| {
         random_bytes[i] = thread_rng().gen();
     });

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,304 +1,38 @@
 #![cfg(test)]
 
 use crate::common::{
-    harness,
+    actions, harness,
     harness::{run_test_harness, Harness},
+    mock_auth_service::{AnyTestUser, GhUser, TestUser},
 };
-use ethers_core::types::{Address, Signature};
+use ethers_core::types::Address;
 use http::StatusCode;
-use kzg_ceremony_crypto::{Arkworks, BatchContribution, BatchTranscript, G2};
+use kzg_ceremony_crypto::{Arkworks, BatchContribution};
 use secrecy::Secret;
-use serde_json::Value;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use url::Url;
 
 mod common;
 
-/// This function acts both as a test and a utility. This way, we'll test the
-/// behavior in a variety of different app states.
-async fn get_and_validate_csrf_token(harness: &Harness, redirect_url: Option<&str>) -> String {
-    let client = reqwest::Client::new();
-
-    let mut url = harness.app_path("auth/request_link");
-    redirect_url.into_iter().for_each(|redirect| {
-        url.query_pairs_mut().append_pair("redirect_to", redirect);
-    });
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap();
-
-    let csrf_for_gh = Url::parse(
-        response
-            .get("github_auth_url")
-            .expect("/auth/request_link response must contain a github_auth_url")
-            .as_str()
-            .expect("github_auth_url must be a string"),
-    )
-    .expect("github_auth_url must be a valid Url")
-    .query_pairs()
-    .into_owned()
-    .collect::<HashMap<_, _>>()
-    .remove("state")
-    .expect("github_auth_url must contain an url-encoded CSRF token");
-
-    let csrf_for_eth = Url::parse(
-        response
-            .get("eth_auth_url")
-            .expect("/auth/request_link response must contain an eth_auth_url")
-            .as_str()
-            .expect("eth_auth_url must be a string"),
-    )
-    .expect("eth_auth_url must be a valid Url")
-    .query_pairs()
-    .into_owned()
-    .collect::<HashMap<_, _>>()
-    .remove("state")
-    .expect("eth_auth_url must contain an url-encoded CSRF token");
-
-    assert_eq!(
-        csrf_for_eth, csrf_for_gh,
-        "CSRF tokens must be the same for all providers but got {} and {}",
-        csrf_for_eth, csrf_for_gh
-    );
-
-    csrf_for_eth
-}
-
-fn entropy_from_str(seed: &str) -> Secret<[u8; 32]> {
-    let padding = "padding".repeat(5);
-    let entropy = format!("{seed}{padding}")
-        .bytes()
-        .take(32)
-        .collect::<Vec<u8>>()
-        .try_into()
-        .unwrap();
-    Secret::new(entropy)
-}
-
-async fn request_gh_callback(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    code: u64,
-    csrf: &str,
-) -> reqwest::Response {
-    http_client
-        .get(harness.options.server.join("auth/callback/github").unwrap())
-        .query(&[("state", csrf), ("code", &code.to_string())])
-        .send()
-        .await
-        .expect("Could not call the endpoint")
-}
-
-async fn extract_session_id_from_auth_response(response: reqwest::Response) -> String {
-    response
-        .json::<Value>()
-        .await
-        .expect("Response must be valid JSON.")
-        .get("session_id")
-        .expect("Response must contain session_id")
-        .as_str()
-        .expect("session_id must be a string")
-        .to_string()
-}
-
-async fn login_gh_user(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    name: String,
-) -> (String, String) {
-    // This code will normally be returned from the auth provider, through a
-    // redirect to the frontend. Here we just get it when registering our fake user,
-    // because it has nothing to do with this backend.
-    let code = harness.create_valid_user(name.clone()).await;
-
-    let csrf = get_and_validate_csrf_token(harness, None).await;
-
-    let callback_result = request_gh_callback(harness, http_client, code, &csrf).await;
-
-    assert_eq!(callback_result.status(), StatusCode::OK);
-    (
-        format!("git|{code}|{name}"),
-        extract_session_id_from_auth_response(callback_result).await,
-    )
-}
-
-async fn request_try_contribute(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    session_id: &str,
-) -> reqwest::Response {
-    http_client
-        .post(harness.options.server.join("lobby/try_contribute").unwrap())
-        .header("Authorization", format!("Bearer {session_id}"))
-        .send()
-        .await
-        .unwrap()
-}
-
-async fn try_contribute(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    session_id: &str,
-) -> BatchContribution {
-    let response = request_try_contribute(harness, http_client, session_id).await;
-
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "Response must be successful"
-    );
-
-    response
-        .json::<BatchContribution>()
-        .await
-        .expect("Successful response must be a contribution")
-}
-
-async fn request_contribute(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    session_id: &str,
-    contribution: &BatchContribution,
-) -> reqwest::Response {
-    http_client
-        .post(harness.options.server.join("contribute").unwrap())
-        .header("Authorization", format!("Bearer {session_id}"))
-        .json(contribution)
-        .send()
-        .await
-        .unwrap()
-}
-
-async fn get_sequencer_eth_address(harness: &Harness, http_client: &reqwest::Client) -> String {
-    http_client
-        .get(harness.app_path("/info/status"))
-        .send()
-        .await
-        .unwrap()
-        .json::<Value>()
-        .await
-        .unwrap()
-        .get("sequencer_address")
-        .unwrap()
-        .as_str()
-        .unwrap()
-        .to_string()
-}
-
-async fn contribute_successfully(
-    harness: &Harness,
-    http_client: &reqwest::Client,
-    session_id: &str,
-    contribution: &BatchContribution,
-    user_id: &str,
-) {
-    let response = request_contribute(harness, http_client, session_id, contribution).await;
-
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "Response must be successful"
-    );
-
-    let response_json = response
-        .json::<Value>()
-        .await
-        .expect("Must return valid JSON");
-
-    let receipt = response_json
-        .get("receipt")
-        .expect("must contain the receipt field")
-        .as_str()
-        .expect("receipt field must be a string");
-
-    let signature: Signature = response_json
-        .get("signature")
-        .expect("must contain signature")
-        .as_str()
-        .expect("signature must be a string")
-        .parse()
-        .expect("must be a valid signature");
-
-    let address: Address = get_sequencer_eth_address(harness, http_client)
-        .await
-        .parse()
-        .unwrap();
-
-    signature
-        .verify(receipt, address)
-        .expect("must be valid signature");
-
-    let receipt_contents =
-        serde_json::from_str::<Value>(receipt).expect("receipt must be a JSON-encoded string");
-    assert_eq!(
-        receipt_contents
-            .get("identity")
-            .expect("must contain identity"),
-        user_id
-    );
-
-    let witness: Vec<G2> = serde_json::from_value(
-        receipt_contents
-            .get("witness")
-            .expect("must contain witness")
-            .clone(),
-    )
-    .expect("witness must be a vector of G2 points");
-
-    assert_eq!(
-        witness,
-        contribution
-            .contributions
-            .iter()
-            .map(|c| c.pot_pubkey)
-            .collect::<Vec<_>>()
-    )
-}
-
-fn assert_includes_contribution(
-    transcript: &BatchTranscript,
-    contribution: &BatchContribution,
-    user_id: &str,
-) {
-    let first_contrib_pubkey = contribution.contributions[0].pot_pubkey;
-    let index_in_transcripts = transcript.transcripts[0]
-        .witness
-        .pubkeys
-        .iter()
-        .position(|pk| pk == &first_contrib_pubkey)
-        .expect("Transcript does not include contribution.");
-    assert_eq!(
-        transcript.participant_ids[index_in_transcripts].to_string(),
-        user_id
-    );
-
-    transcript
-        .transcripts
-        .iter()
-        .zip(contribution.contributions.iter())
-        .for_each(|(t, c)| {
-            assert_eq!(t.witness.products[index_in_transcripts], c.powers.g1[1]);
-            assert_eq!(t.witness.pubkeys[index_in_transcripts], c.pot_pubkey);
-        })
-}
-
 #[tokio::test]
 async fn test_auth_request_link() {
     let harness = run_test_harness().await;
-    get_and_validate_csrf_token(&harness, None).await;
+    actions::get_and_validate_csrf_token(&harness, None).await;
 }
 
 #[tokio::test]
 async fn test_gh_auth_happy_path() {
     let harness = run_test_harness().await;
     let http_client = reqwest::Client::new();
-    login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
+    actions::create_and_login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
+}
+
+#[tokio::test]
+async fn test_eth_auth_happy_path() {
+    let harness = run_test_harness().await;
+    let http_client = reqwest::Client::new();
+    let user = harness.create_eth_user().await;
+    actions::login(&harness, &http_client, &user).await;
 }
 
 #[tokio::test]
@@ -308,11 +42,13 @@ async fn test_gh_auth_with_custom_frontend_redirect() {
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap();
-    let csrf =
-        get_and_validate_csrf_token(&harness, Some("https://my.magical.frontend/post-sign-in"))
-            .await;
-    let code = harness.create_valid_user("kustosz".to_string()).await;
-    let auth_response = request_gh_callback(&harness, &client, code, &csrf).await;
+    let csrf = actions::get_and_validate_csrf_token(
+        &harness,
+        Some("https://my.magical.frontend/post-sign-in"),
+    )
+    .await;
+    let user = harness.create_gh_user("kustosz".to_string()).await;
+    let auth_response = actions::request_auth_callback(&harness, &client, &user, &csrf).await;
     assert_eq!(auth_response.status(), StatusCode::SEE_OTHER);
     let location_header = auth_response
         .headers()
@@ -324,7 +60,7 @@ async fn test_gh_auth_with_custom_frontend_redirect() {
     assert_eq!(redirected_to.host_str(), Some("my.magical.frontend"));
     assert_eq!(redirected_to.path(), "/post-sign-in");
     let params: HashMap<_, _> = redirected_to.query_pairs().into_owned().collect();
-    assert_eq!(params["sub"], format!("git|{code}|kustosz"));
+    assert_eq!(params["sub"], user.identity());
     assert_eq!(params["nickname"], "kustosz");
     assert_eq!(params["provider"], "Github");
     assert!(params.get("session_id").is_some());
@@ -339,10 +75,20 @@ async fn test_gh_auth_errors_with_custom_frontend_redirect() {
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap();
-    let csrf =
-        get_and_validate_csrf_token(&harness, Some("https://my.magical.frontend/post-sign-in"))
-            .await;
-    let auth_response = request_gh_callback(&harness, &client, 12345, &csrf).await;
+    let csrf = actions::get_and_validate_csrf_token(
+        &harness,
+        Some("https://my.magical.frontend/post-sign-in"),
+    )
+    .await;
+    let invalid_user = TestUser {
+        id:   12344,
+        user: AnyTestUser::Gh(GhUser {
+            name:       "foo".to_string(),
+            created_at: "2022-01-01T00:00:00Z".to_string(),
+        }),
+    };
+    let auth_response =
+        actions::request_auth_callback(&harness, &client, &invalid_user, &csrf).await;
     assert_eq!(auth_response.status(), StatusCode::SEE_OTHER);
     let location_header = auth_response
         .headers()
@@ -359,13 +105,14 @@ async fn test_gh_auth_errors_with_custom_frontend_redirect() {
 }
 
 #[tokio::test]
-async fn test_contribution_happy_path() {
+async fn test_gh_contribution_happy_path() {
     let harness = run_test_harness().await;
     let http_client = reqwest::Client::new();
 
-    let (user_id, session_id) = login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
+    let (user, session_id) =
+        actions::create_and_login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
 
-    let mut contribution = try_contribute(&harness, &http_client, &session_id).await;
+    let mut contribution = actions::try_contribute(&harness, &http_client, &session_id).await;
 
     // not only is it unguessable, it is also 32 characters long and we depend on
     // this.
@@ -379,7 +126,14 @@ async fn test_contribution_happy_path() {
         .add_entropy::<Arkworks>(&entropy)
         .expect("Adding entropy must be possible");
 
-    contribute_successfully(&harness, &http_client, &session_id, &contribution, &user_id).await;
+    actions::contribute_successfully(
+        &harness,
+        &http_client,
+        &session_id,
+        &contribution,
+        &user.identity(),
+    )
+    .await;
 
     let transcript = harness.read_transcript_file().await;
 
@@ -419,15 +173,15 @@ async fn test_contribution_happy_path() {
 async fn test_double_contribution() {
     let harness = run_test_harness().await;
     let http_client = reqwest::Client::new();
-    let auth_code = harness.create_valid_user("kustosz".to_string()).await;
-    let csrf = get_and_validate_csrf_token(&harness, None).await;
-    let user_id = format!("git|{auth_code}|kustosz");
-    let session_id = extract_session_id_from_auth_response(
-        request_gh_callback(&harness, &http_client, auth_code, &csrf).await,
+    let user = harness.create_gh_user("kustosz".to_string()).await;
+    let csrf = actions::get_and_validate_csrf_token(&harness, None).await;
+    let user_id = user.identity();
+    let session_id = actions::extract_session_id_from_auth_response(
+        actions::request_auth_callback(&harness, &http_client, &user, &csrf).await,
     )
     .await;
 
-    let mut contribution = try_contribute(&harness, &http_client, &session_id).await;
+    let mut contribution = actions::try_contribute(&harness, &http_client, &session_id).await;
 
     // not only is it unguessable, it is also 32 characters long and we depend on
     // this.
@@ -442,19 +196,20 @@ async fn test_double_contribution() {
         .expect("Adding entropy must be possible");
 
     // First, successful contribution;
-    contribute_successfully(&harness, &http_client, &session_id, &contribution, &user_id).await;
+    actions::contribute_successfully(&harness, &http_client, &session_id, &contribution, &user_id)
+        .await;
     let transcript_with_first_contrib = harness.read_transcript_file().await;
-    assert_includes_contribution(&transcript_with_first_contrib, &contribution, &user_id);
+    actions::assert_includes_contribution(&transcript_with_first_contrib, &contribution, &user_id);
 
     // Try contributing again right away – fails because the contribution spot is
     // emptied
     let second_contribute_response =
-        request_contribute(&harness, &http_client, &session_id, &contribution).await;
+        actions::request_contribute(&harness, &http_client, &session_id, &contribution).await;
     assert_eq!(second_contribute_response.status(), StatusCode::BAD_REQUEST);
 
     // Try pinging the lobby again – fails because the user got logged out
     let second_try_contribute_response =
-        request_try_contribute(&harness, &http_client, &session_id).await;
+        actions::request_try_contribute(&harness, &http_client, &session_id).await;
     assert_eq!(
         second_try_contribute_response.status(),
         StatusCode::UNAUTHORIZED
@@ -462,8 +217,9 @@ async fn test_double_contribution() {
 
     // Try logging in again – fails because the user is banned from further use of
     // the app.
-    let new_csrf = get_and_validate_csrf_token(&harness, None).await;
-    let gh_login_response = request_gh_callback(&harness, &http_client, auth_code, &new_csrf).await;
+    let new_csrf = actions::get_and_validate_csrf_token(&harness, None).await;
+    let gh_login_response =
+        actions::request_auth_callback(&harness, &http_client, &user, &new_csrf).await;
     assert_eq!(gh_login_response.status(), StatusCode::BAD_REQUEST);
 
     let transcript_after_attempts = harness.read_transcript_file().await;
@@ -480,61 +236,66 @@ async fn test_double_contribution_when_allowed() {
         .run()
         .await;
     let http_client = reqwest::Client::new();
-    let auth_code = harness.create_valid_user("kustosz".to_string()).await;
-    let user_id = format!("git|{auth_code}|kustosz");
-    let csrf = get_and_validate_csrf_token(&harness, None).await;
-    let session_id = extract_session_id_from_auth_response(
-        request_gh_callback(&harness, &http_client, auth_code, &csrf).await,
+    let user = harness.create_gh_user("kustosz".to_string()).await;
+    let user_id = user.identity();
+    let csrf = actions::get_and_validate_csrf_token(&harness, None).await;
+    let session_id = actions::extract_session_id_from_auth_response(
+        actions::request_auth_callback(&harness, &http_client, &user, &csrf).await,
     )
     .await;
 
-    let mut contribution1 = try_contribute(&harness, &http_client, &session_id).await;
+    let mut contribution1 = actions::try_contribute(&harness, &http_client, &session_id).await;
 
     contribution1
-        .add_entropy::<Arkworks>(&entropy_from_str("such an unguessable string, wow!"))
+        .add_entropy::<Arkworks>(&actions::entropy_from_str(
+            "such an unguessable string, wow!",
+        ))
         .expect("Adding entropy must be possible");
 
-    contribute_successfully(
+    actions::contribute_successfully(
         &harness,
         &http_client,
         &session_id,
         &contribution1,
-        &format!("git|{auth_code}|kustosz"),
+        &user_id,
     )
     .await;
 
-    let new_csrf = get_and_validate_csrf_token(&harness, None).await;
-    let session_id = extract_session_id_from_auth_response(
-        request_gh_callback(&harness, &http_client, auth_code, &new_csrf).await,
+    let new_csrf = actions::get_and_validate_csrf_token(&harness, None).await;
+    let session_id = actions::extract_session_id_from_auth_response(
+        actions::request_auth_callback(&harness, &http_client, &user, &new_csrf).await,
     )
     .await;
 
-    let mut contribution2 = try_contribute(&harness, &http_client, &session_id).await;
+    let mut contribution2 = actions::try_contribute(&harness, &http_client, &session_id).await;
     contribution2
-        .add_entropy::<Arkworks>(&entropy_from_str("another unguessable string, wow!"))
+        .add_entropy::<Arkworks>(&actions::entropy_from_str(
+            "another unguessable string, wow!",
+        ))
         .expect("Adding entropy must be possible");
 
-    contribute_successfully(
+    actions::contribute_successfully(
         &harness,
         &http_client,
         &session_id,
         &contribution2,
-        &format!("git|{auth_code}|kustosz"),
+        &user_id,
     )
     .await;
     let transcript = harness.read_transcript_file().await;
-    assert_includes_contribution(&transcript, &contribution1, &user_id);
-    assert_includes_contribution(&transcript, &contribution2, &user_id);
+    actions::assert_includes_contribution(&transcript, &contribution1, &user_id);
+    actions::assert_includes_contribution(&transcript, &contribution2, &user_id);
 }
 
 async fn well_behaved_participant(
     harness: &Harness,
     client: &reqwest::Client,
     name: String,
-) -> (BatchContribution, String) {
-    let (user_id, session_id) = login_gh_user(harness, client, name.clone()).await;
+) -> (BatchContribution, TestUser) {
+    let (user, session_id) = actions::create_and_login_gh_user(harness, client, name.clone()).await;
     let mut contribution = loop {
-        let try_contribute_response = request_try_contribute(harness, client, &session_id).await;
+        let try_contribute_response =
+            actions::request_try_contribute(harness, client, &session_id).await;
         assert_eq!(try_contribute_response.status(), StatusCode::OK);
         let maybe_contribution = try_contribute_response
             .json::<BatchContribution>()
@@ -561,14 +322,22 @@ async fn well_behaved_participant(
     contribution
         .add_entropy::<Arkworks>(&entropy)
         .expect("Adding entropy must be possible");
-    contribute_successfully(harness, client, &session_id, &contribution, &user_id).await;
-    (contribution, user_id)
+    actions::contribute_successfully(
+        harness,
+        client,
+        &session_id,
+        &contribution,
+        &user.identity(),
+    )
+    .await;
+    (contribution, user)
 }
 
 async fn slow_compute_participant(harness: &Harness, client: &reqwest::Client, name: String) {
-    let (_, session_id) = login_gh_user(harness, client, name.clone()).await;
+    let (_, session_id) = actions::create_and_login_gh_user(harness, client, name.clone()).await;
     let mut contribution = loop {
-        let try_contribute_response = request_try_contribute(harness, client, &session_id).await;
+        let try_contribute_response =
+            actions::request_try_contribute(harness, client, &session_id).await;
         assert_eq!(try_contribute_response.status(), StatusCode::OK);
         let maybe_contribution = try_contribute_response
             .json::<BatchContribution>()
@@ -599,7 +368,7 @@ async fn slow_compute_participant(harness: &Harness, client: &reqwest::Client, n
         .add_entropy::<Arkworks>(&entropy)
         .expect("Adding entropy must be possible");
 
-    let response = request_contribute(harness, client, &session_id, &contribution).await;
+    let response = actions::request_contribute(harness, client, &session_id, &contribution).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -623,9 +392,9 @@ async fn test_large_lobby() {
         .collect();
 
     let final_transcript = harness.read_transcript_file().await;
-    contributions
-        .iter()
-        .for_each(|(c, user_id)| assert_includes_contribution(&final_transcript, c, &user_id));
+    contributions.iter().for_each(|(c, user)| {
+        actions::assert_includes_contribution(&final_transcript, c, &user.identity())
+    });
 }
 
 #[tokio::test]
@@ -655,8 +424,9 @@ async fn test_large_lobby_with_misbehaving_users() {
 
     let final_transcript = harness.read_transcript_file().await;
     contributions.iter().for_each(|oc| {
-        oc.iter()
-            .for_each(|(c, user_id)| assert_includes_contribution(&final_transcript, c, user_id))
+        oc.iter().for_each(|(c, user_id)| {
+            actions::assert_includes_contribution(&final_transcript, c, &user_id.identity())
+        })
     });
 
     let should_accept_count = contributions.iter().filter(|e| e.is_some()).count();
@@ -682,9 +452,10 @@ async fn test_contribution_after_lobby_cleanup() {
         .await;
     let http_client = reqwest::Client::new();
 
-    let (user_id, session_id) = login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
+    let (user, session_id) =
+        actions::create_and_login_gh_user(&harness, &http_client, "kustosz".to_string()).await;
 
-    let mut contribution = try_contribute(&harness, &http_client, &session_id).await;
+    let mut contribution = actions::try_contribute(&harness, &http_client, &session_id).await;
 
     let entropy = "such an unguessable string, wow!"
         .bytes()
@@ -698,5 +469,12 @@ async fn test_contribution_after_lobby_cleanup() {
 
     tokio::time::sleep(Duration::from_millis(300)).await;
 
-    contribute_successfully(&harness, &http_client, &session_id, &contribution, &user_id).await;
+    actions::contribute_successfully(
+        &harness,
+        &http_client,
+        &session_id,
+        &contribution,
+        &user.identity(),
+    )
+    .await;
 }


### PR DESCRIPTION
Currently only works with the BLST engine, to make it deployable ASAP (and converge on formats with frontends). Adding BLS signatures with Arkworks is going to be more involved.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
