### PR TITLE
Migrate to pushing Docker Images to Ethereum org's docker-hub

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -280,19 +280,19 @@ jobs:
         uses: docker/login-action@v2
         with:
           # Access token `kzg-ceremony-sequencer-github-actions`
-          username: remcob
+          username: carlbeek
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push commit tag
         run: |
           docker pull $IMAGE_ID
-          docker tag $IMAGE_ID remcob/kzg-ceremony-sequencer:${{ github.sha }}
-          docker push remcob/kzg-ceremony-sequencer:${{ github.sha }}
+          docker tag $IMAGE_ID ethereum/kzg-ceremony-sequencer:${{ github.sha }}
+          docker push ethereum/kzg-ceremony-sequencer:${{ github.sha }}
       - name: Push latest tag
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
         run: |
           docker pull $IMAGE_ID
-          docker tag $IMAGE_ID remcob/kzg-ceremony-sequencer:latest
-          docker push remcob/kzg-ceremony-sequencer:latest
+          docker tag $IMAGE_ID ethereum/kzg-ceremony-sequencer:latest
+          docker push ethereum/kzg-ceremony-sequencer:latest
 
   deploy_on_fly:
     name: Deploy on fly.io

--- a/Readme.md
+++ b/Readme.md
@@ -7,10 +7,10 @@
 
 This implements [KZG Ceremony Specification](https://github.com/ethereum/kzg-ceremony-specs).
 
-The latest build is available as a container on [ghcr.io/ethereum/kzg-ceremony-sequencer](https://github.com/ethereum/kzg-ceremony-sequencer/pkgs/container/kzg-ceremony-sequencer):
+The latest build is available as a container on [ethereum/kzg-ceremony-sequencer](https://hub.docker.com/repository/docker/ethereum/kzg-ceremony-sequencer/general):
 
 ```shell
-docker run ghcr.io/ethereum/kzg-ceremony-sequencer:latest
+docker run ethereum/kzg-ceremony-sequencer:latest
 ```
 
 ## Setup


### PR DESCRIPTION
## Motivation

We're currently using @recmo's DockerHub account to host the images, but I'm now set up with push access to the `ethereum` DockerHub account so we should be able to use that now. Long term I'd like to migrate over to DockerHub automated builds, but there seems to be an issue with doing so and we have an open ticket with them.

## Solution
Push to `ethereum` DockerHub account using my (`carlbeek`) account. Note that this also requires changing the `DOCKERHUB_TOKEN` secret which I won't do until this PR is merged as it will break existing pushes.