### PR TITLE
getPotPubkeys and subgroupCheck after contribution

### DIFF
--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -55,6 +55,20 @@ fn derive_taus<E: Engine>(entropy: &Entropy, size: usize) -> Vec<Tau> {
         .collect()
 }
 
+pub fn get_pot_pubkeys<E: Engine>(entropy: &Entropy) -> Vec<G2> {
+    let taus = derive_taus::<E>(entropy, 4);
+    let result: Vec<G2> = taus
+        .into_par_iter()
+        .map(|tau| {
+            let mut temp = [G2::one(), G2::one()];
+            E::add_tau_g2(&tau, &mut temp).unwrap();
+            let g2 = temp[1];
+            g2
+        })
+        .collect();
+    result
+}
+
 #[cfg(feature = "bench")]
 #[doc(hidden)]
 pub mod bench {

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -41,6 +41,22 @@ impl BatchContribution {
             });
         res
     }
+
+    #[instrument(level = "info", skip_all, fields(n=self.contributions.len()))]
+    pub fn validate<E: Engine>(
+        &mut self,
+    ) -> Result<(), CeremoniesError> {
+        let res = self
+            .contributions
+            .par_iter_mut()
+            .enumerate()
+            .try_for_each(|(i, contribution)| {
+                contribution
+                    .validate::<E>()
+                    .map_err(|e| CeremoniesError::InvalidCeremony(i, e))
+            });
+        res
+    }
 }
 
 fn derive_taus<E: Engine>(entropy: &Entropy, size: usize) -> Vec<Tau> {

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -29,11 +29,7 @@ impl Contribution {
         tau: &Tau,
         identity: &Identity,
     ) -> Result<(), CeremonyError> {
-        // Validate points
-        // TODO: Do this after we submit result to contribute faster.
-        E::validate_g1(&self.powers.g1)?;
-        E::validate_g2(&self.powers.g2)?;
-        E::validate_g2(&[self.pot_pubkey])?;
+        // Validate points after computation to contribute faster
 
         // Add powers of tau
         E::add_tau_g1(tau, &mut self.powers.g1)?;
@@ -43,6 +39,18 @@ impl Contribution {
         self.bls_signature = BlsSignature::sign::<E>(identity.to_string().as_bytes(), tau);
         self.pot_pubkey = temp[1];
 
+        Ok(())
+    }
+
+    /// Performs validations in the contribution.
+    #[instrument(level = "info", skip_all, , fields(n1=self.powers.g1.len(), n2=self.powers.g2.len()))]
+    pub fn validate<E: Engine>(
+        &mut self,
+    ) -> Result<(), CeremonyError> {
+        // Validate points
+        E::validate_g1(&self.powers.g1)?;
+        E::validate_g2(&self.powers.g2)?;
+        E::validate_g2(&[self.pot_pubkey])?;
         Ok(())
     }
 }

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -14,7 +14,7 @@ mod blst;
 mod both;
 
 use crate::{CeremonyError, F, G1, G2};
-use secrecy::Secret;
+pub use secrecy::Secret;
 
 #[cfg(feature = "arkworks")]
 pub use self::arkworks::Arkworks;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -16,12 +16,14 @@ mod transcript;
 
 pub use crate::{
     batch_contribution::BatchContribution,
+    batch_contribution::get_pot_pubkeys,
     batch_transcript::BatchTranscript,
     contribution::Contribution,
-    engine::{Engine, Entropy, Tau},
+    engine::{Engine, Entropy, Tau, Secret},
     error::{CeremoniesError, CeremonyError, ErrorCode, ParseError},
     group::{F, G1, G2},
     powers::Powers,
+    signature::identity::Identity,
     transcript::Transcript,
 };
 


### PR DESCRIPTION
This PR contains two important features:

1. **getPotPubkeys:** the current user workflow for ECDSA is:
    1. user logs in using Metamask
    2. user generates entropy
    3. user ECDSA-sign the entropy (potPubkeys) using Metamask
    4. user enters in the lobby and waits
    5. browser automatically contributes and upload contribution
We need the potPubkeys before the computation phase in order to execute step 3. Step 3 has to be done before computation because users could leave the browser waiting in the lobby and forget to return and ECDSA-sign with Metamask (requires user action). That is why I implemented the `get_pot_pubkeys` in the `batch_contribution` section.

2. **subgroupChecks:** previously we were performing subgroups checks in the `add_entropy` (aka contribute) function. We were planning on doing the checks after the computation in order to contribute faster. I implemented a `validate` in `batch_contribution` to be able to call the subgroup checks after the computation is done. I also delete the checks in the `add_entropy` function to make it faster.

