### PR TITLE
Make ecdsa_signature camel case

### DIFF
--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct BatchContribution {
     pub contributions:   Vec<Contribution>,
     pub ecdsa_signature: EcdsaSignature,


### PR DESCRIPTION
## Motivation
Make the batch contributon json align with the [contributionSchema.json](https://github.com/ethereum/kzg-ceremony-specs/blob/master/apiSpec/contributionSchema.json). Currently the ecdsa_signature is not camel case when serializing/deseriliazing.

## Solution
Add `rename_all = "camelCase"` to the BatchContribution struct

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
