### PR TITLE
Record contributions in a background task to prevent cancelation

### DIFF
--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -38,8 +38,8 @@ pub enum ContributeError {
     NotUsersTurn,
     #[error("contribution invalid: {0}")]
     InvalidContribution(#[from] CeremoniesError),
-    #[error("our signature error: {0}")]
-    OurSignature(SignatureError),
+    #[error("receipt signing error: {0}")]
+    ReceiptSigning(SignatureError),
     #[error("storage error: {0}")]
     StorageError(#[from] StorageError),
     #[error("background task error: {0}")]
@@ -94,7 +94,7 @@ pub async fn contribute(
         let (signed_msg, signature) = receipt
             .sign(&keys)
             .await
-            .map_err(ContributeError::OurSignature)?;
+            .map_err(ContributeError::ReceiptSigning)?;
 
         write_json_file(
             options.transcript_file,
@@ -118,7 +118,7 @@ pub async fn contribute(
     if let Err(err) = &res {
         if matches!(
             err,
-            ContributeError::OurSignature(_)
+            ContributeError::ReceiptSigning(_)
                 | ContributeError::StorageError(_)
                 | ContributeError::TaskError(_)
         ) {

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -133,6 +133,8 @@ pub async fn contribute_abort(
     Extension(lobby_state): Extension<SharedLobbyState>,
     Extension(storage): Extension<PersistentStorage>,
 ) -> Result<(), ContributeError> {
+    // Abort the contribution in the background,
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
     tokio::spawn(async move {
         lobby_state
             .abort_contribution(&session_id)

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -17,10 +17,12 @@ use serde::Serialize;
 use std::sync::atomic::Ordering;
 use strum::IntoStaticStr;
 use thiserror::Error;
+use tokio::task::JoinError;
+use tracing::error;
 
 #[derive(Serialize)]
 pub struct ContributeReceipt {
-    receipt:   String,
+    receipt: String,
     signature: Signature,
 }
 
@@ -36,10 +38,12 @@ pub enum ContributeError {
     NotUsersTurn,
     #[error("contribution invalid: {0}")]
     InvalidContribution(#[from] CeremoniesError),
-    #[error("signature error: {0}")]
-    Signature(SignatureError),
+    #[error("our signature error: {0}")]
+    OurSignature(SignatureError),
     #[error("storage error: {0}")]
     StorageError(#[from] StorageError),
+    #[error("background task error: {0}")]
+    TaskError(#[from] JoinError),
 }
 
 impl ErrorCode for ContributeError {
@@ -59,53 +63,69 @@ pub async fn contribute(
     Extension(num_contributions): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> Result<ContributeReceipt, ContributeError> {
-    let id_token = lobby_state
-        .begin_contributing(&session_id)
-        .await
-        .map_err(|_| ContributeError::NotUsersTurn)?
-        .token;
+    // Handle the contribution in the background, so that request cancelation doesn't interrupt it.
+    let res = tokio::spawn(async move {
+        let id_token = lobby_state
+            .begin_contributing(&session_id)
+            .await
+            .map_err(|_| ContributeError::NotUsersTurn)?
+            .token;
 
-    let result = {
-        let mut transcript = shared_transcript.write().await;
-        transcript
-            .verify_add::<Engine>(contribution.clone(), id_token.identity.clone())
-            .map_err(ContributeError::InvalidContribution)
-    };
+        let result = {
+            let mut transcript = shared_transcript.write().await;
+            transcript
+                .verify_add::<Engine>(contribution.clone(), id_token.identity.clone())
+                .map_err(ContributeError::InvalidContribution)
+        };
 
-    if let Err(e) = result {
+        if let Err(e) = result {
+            lobby_state.clear_current_contributor().await;
+            storage
+                .expire_contribution(&id_token.unique_identifier())
+                .await?;
+            return Err(e);
+        }
+
+        let receipt = Receipt {
+            identity: id_token.identity,
+            witness: contribution.receipt(),
+        };
+
+        let (signed_msg, signature) = receipt
+            .sign(&keys)
+            .await
+            .map_err(ContributeError::OurSignature)?;
+
+        write_json_file(
+            options.transcript_file,
+            options.transcript_in_progress_file,
+            shared_transcript,
+        )
+        .await;
+
         lobby_state.clear_current_contributor().await;
-        storage
-            .expire_contribution(&id_token.unique_identifier())
-            .await?;
-        return Err(e);
-    }
+        storage.finish_contribution(&session_id.0).await?;
 
-    let receipt = Receipt {
-        identity: id_token.identity,
-        witness:  contribution.receipt(),
-    };
+        num_contributions.fetch_add(1, Ordering::Relaxed);
 
-    let (signed_msg, signature) = receipt
-        .sign(&keys)
-        .await
-        .map_err(ContributeError::Signature)?;
-
-    write_json_file(
-        options.transcript_file,
-        options.transcript_in_progress_file,
-        shared_transcript,
-    )
-    .await;
-
-    lobby_state.clear_current_contributor().await;
-    storage.finish_contribution(&session_id.0).await?;
-
-    num_contributions.fetch_add(1, Ordering::Relaxed);
-
-    Ok(ContributeReceipt {
-        receipt: signed_msg,
-        signature,
+        Ok(ContributeReceipt {
+            receipt: signed_msg,
+            signature,
+        })
     })
+    .await
+    .unwrap_or_else(|e| Err(ContributeError::TaskError(e)));
+    if let Err(err) = &res {
+        if matches!(
+            err,
+            ContributeError::OurSignature(_)
+                | ContributeError::StorageError(_)
+                | ContributeError::TaskError(_)
+        ) {
+            error!(?err, "unexpected error recording contribution");
+        }
+    }
+    res
 }
 
 pub async fn contribute_abort(
@@ -220,10 +240,13 @@ mod tests {
         let transcript_1 = {
             let mut transcript = transcript.clone();
             transcript
-                .verify_add::<Engine>(contribution_1.clone(), Identity::Github {
-                    id:       1234,
-                    username: "test_user".to_string(),
-                })
+                .verify_add::<Engine>(
+                    contribution_1.clone(),
+                    Identity::Github {
+                        id: 1234,
+                        username: "test_user".to_string(),
+                    },
+                )
                 .unwrap();
             transcript
         };
@@ -231,10 +254,13 @@ mod tests {
         let transcript_2 = {
             let mut transcript = transcript_1.clone();
             transcript
-                .verify_add::<Engine>(contribution_2.clone(), Identity::Github {
-                    id:       1234,
-                    username: "test_user".to_string(),
-                })
+                .verify_add::<Engine>(
+                    contribution_2.clone(),
+                    Identity::Github {
+                        id: 1234,
+                        username: "test_user".to_string(),
+                    },
+                )
                 .unwrap();
             transcript
         };

--- a/src/api/v1/error_response.rs
+++ b/src/api/v1/error_response.rs
@@ -84,8 +84,9 @@ impl IntoResponse for ContributeError {
         let (status, body) = match self {
             Self::NotUsersTurn => (StatusCode::BAD_REQUEST, error_to_json(&self)),
             Self::InvalidContribution(e) => return CeremoniesErrorFormatter(e).into_response(),
-            Self::Signature(err) => return err.into_response(),
+            Self::OurSignature(err) => return err.into_response(),
             Self::StorageError(err) => return err.into_response(),
+            Self::TaskError(_) => (StatusCode::INTERNAL_SERVER_ERROR, error_to_json(&self)),
         };
 
         (status, body).into_response()

--- a/src/api/v1/error_response.rs
+++ b/src/api/v1/error_response.rs
@@ -84,7 +84,7 @@ impl IntoResponse for ContributeError {
         let (status, body) = match self {
             Self::NotUsersTurn => (StatusCode::BAD_REQUEST, error_to_json(&self)),
             Self::InvalidContribution(e) => return CeremoniesErrorFormatter(e).into_response(),
-            Self::OurSignature(err) => return err.into_response(),
+            Self::ReceiptSigning(err) => return err.into_response(),
             Self::StorageError(err) => return err.into_response(),
             Self::TaskError(_) => (StatusCode::INTERNAL_SERVER_ERROR, error_to_json(&self)),
         };

--- a/src/api/v1/error_response.rs
+++ b/src/api/v1/error_response.rs
@@ -102,6 +102,7 @@ impl IntoResponse for TryContributeError {
             }
             Self::AnotherContributionInProgress => (StatusCode::OK, error_to_json(&self)),
             Self::StorageError(err) => return err.into_response(),
+            Self::TaskError(_) => (StatusCode::INTERNAL_SERVER_ERROR, error_to_json(&self)),
         };
 
         (status, body).into_response()

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -81,6 +81,8 @@ pub async fn try_contribute(
         .await
         .unwrap_or(Err(TryContributeError::UnknownSessionId))?;
 
+    // Attempt to set ourselves as the current contributor in the background,
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
     tokio::spawn(async move {
         lobby_state.enter_lobby(&session_id).await?;
 


### PR DESCRIPTION
This PR fixes #133 by running the `/contribute` handler in a background task to prevent it from being canceled if the user cancels their request. It then awaits that background task to give the result back to the user. I also added logging for other errors that would cause the sequencer to get stuck, such as failing to sign the receipt, or a panic caused by an error writing the transcript file.