### PR TITLE
Fix for #135 (KZG-01)

### DIFF
--- a/crypto/src/engine/blst/g1.rs
+++ b/crypto/src/engine/blst/g1.rs
@@ -2,7 +2,7 @@ use crate::{ParseError, G1};
 use blst::{
     blst_p1, blst_p1_affine, blst_p1_affine_compress, blst_p1_affine_in_g1, blst_p1_from_affine,
     blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p1s_mult_pippenger,
-    blst_p1s_mult_pippenger_scratch_sizeof, blst_p1s_to_affine, blst_scalar, limb_t,
+    blst_p1s_mult_pippenger_scratch_sizeof, blst_p1s_to_affine, blst_scalar, limb_t, BLST_ERROR,
 };
 use std::{mem::size_of, ptr};
 
@@ -10,11 +10,12 @@ impl TryFrom<G1> for blst_p1_affine {
     type Error = ParseError;
 
     fn try_from(g1: G1) -> Result<Self, Self::Error> {
-        unsafe {
-            let mut p = Self::default();
-            blst_p1_uncompress(&mut p, g1.0.as_ptr());
-            Ok(p)
+        let mut p = Self::default();
+        let result = unsafe { blst_p1_uncompress(&mut p, g1.0.as_ptr()) };
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(ParseError::InvalidCompression);
         }
+        Ok(p)
     }
 }
 

--- a/crypto/src/engine/blst/g2.rs
+++ b/crypto/src/engine/blst/g2.rs
@@ -2,7 +2,7 @@ use crate::{ParseError, G2};
 use blst::{
     blst_p2, blst_p2_affine, blst_p2_affine_compress, blst_p2_affine_in_g2, blst_p2_from_affine,
     blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_p2s_mult_pippenger,
-    blst_p2s_mult_pippenger_scratch_sizeof, blst_p2s_to_affine, blst_scalar, limb_t,
+    blst_p2s_mult_pippenger_scratch_sizeof, blst_p2s_to_affine, blst_scalar, limb_t, BLST_ERROR,
 };
 use std::{mem::size_of, ptr};
 
@@ -10,11 +10,12 @@ impl TryFrom<G2> for blst_p2_affine {
     type Error = ParseError;
 
     fn try_from(g2: G2) -> Result<Self, Self::Error> {
-        unsafe {
-            let mut p = Self::default();
-            blst_p2_uncompress(&mut p, g2.0.as_ptr());
-            Ok(p)
+        let mut p = Self::default();
+        let result = unsafe { blst_p2_uncompress(&mut p, g2.0.as_ptr()) };
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(ParseError::InvalidCompression);
         }
+        Ok(p)
     }
 }
 

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -110,6 +110,20 @@ pub mod tests {
             assert_eq!(points1, points2);
         });
     }
+
+    #[test]
+    fn test_validate_g1() {
+        let g1 = G1([0u8; 48]);
+        assert!(BLST::validate_g1(&[g1]).is_err());
+        assert!(Arkworks::validate_g1(&[g1]).is_err());
+    }
+
+    #[test]
+    fn test_validate_g2() {
+        let g2 = G2([0u8; 96]);
+        assert!(BLST::validate_g2(&[g2]).is_err());
+        assert!(Arkworks::validate_g2(&[g2]).is_err());
+    }
 }
 
 #[cfg(feature = "bench")]

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -105,6 +105,8 @@ pub enum ParseError {
     InvalidXCoordinate,
     #[error("curve point is not in prime order subgroup")]
     InvalidSubgroup,
+    #[error("Error while uncompressing point")]
+    InvalidCompression,
 }
 
 impl ErrorCode for ParseError {


### PR DESCRIPTION
In order to address #135 (KZG-01) following changes were made: 

- Introduces the missing check on the result of `blst_p1_uncompress` and `blst_p1_uncompress`.
- New `ParseError::InvalidCompression` was introduced, reusing the existing `ParseError::NotCompressed` seemed not like a good fit, since it's used in a more specific case of handling the zcash format for the Arkworks engine.
- Two testcases replicating the behaviour as pointed out by the audit.
