### PR TITLE
Make keygen consistent and secure accross both engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "ethers-core",
  "hex",
  "hex-literal",
+ "hkdf",
  "proptest",
  "rand",
  "rand_chacha",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -34,6 +34,7 @@ digest = "0.10"
 ethers-core = { version = "1.0.0", features = ["eip712"] }
 hex = "0.4.3"
 hex-literal = "0.3.4"
+hkdf = "0.12.3"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.5.3"

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -236,13 +236,12 @@ impl Engine for Arkworks {
 // Implementation of the KeyGen function as specified in
 // https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/
 fn bls_keygen(ikm: [u8; 64]) -> Fr {
+    // the `L` value, precomputed from the formula given in the spec
+    const L: u8 = 48;
     let mut full_ikm = [0u8; 65];
     full_ikm[..64].copy_from_slice(&ikm);
     full_ikm[64] = 0;
-
-    // the `L` value, precomputed from the formula given in the spec
-    const L: u8 = 48;
-    let key_info = [0 as u8, L];
+    let key_info = [0, L];
 
     let mut hasher = Sha256::new();
     hasher.update(b"BLS-SIG-KEYGEN-SALT-");
@@ -250,7 +249,7 @@ fn bls_keygen(ikm: [u8; 64]) -> Fr {
 
     loop {
         let hk = Hkdf::<Sha256>::new(Some(&salt), &full_ikm);
-        let mut out = [0 as u8; 48];
+        let mut out = [0; L as usize];
         hk.expand(&key_info, &mut out).unwrap();
         let fr = Fr::from_be_bytes_mod_order(&out);
         if fr != Fr::zero() {

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -23,6 +23,8 @@ use ark_ec::{
     msm::VariableBaseMSM, wnaf::WnafContext, AffineCurve, PairingEngine, ProjectiveCurve,
 };
 use ark_ff::{BigInteger, One, PrimeField, UniformRand, Zero};
+use digest::Digest;
+use hkdf::Hkdf;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::prelude::*;
@@ -136,7 +138,8 @@ impl Engine for Arkworks {
         // Generate tau by reducing 512 bits of entropy modulo prime.
         let mut large = [0_u8; 64];
         rng.fill(&mut large);
-        let fr = Fr::from_le_bytes_mod_order(&large[..]);
+
+        let fr = bls_keygen(large);
 
         // Convert to Tau
         let le_bytes = fr.into_repr().to_bytes_le();
@@ -227,6 +230,35 @@ impl Engine for Arkworks {
         let c2 = Bls12_381::pairing(sig, G2Affine::prime_subgroup_generator());
 
         c1 == c2
+    }
+}
+
+// Implementation of the KeyGen function as specified in
+// https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/
+fn bls_keygen(ikm: [u8; 64]) -> Fr {
+    let mut full_ikm = [0u8; 65];
+    full_ikm[..64].copy_from_slice(&ikm);
+    full_ikm[64] = 0;
+
+    // the `L` value, precomputed from the formula given in the spec
+    const L: u8 = 48;
+    let key_info = [0 as u8, L];
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"BLS-SIG-KEYGEN-SALT-");
+    let mut salt = hasher.finalize();
+
+    loop {
+        let hk = Hkdf::<Sha256>::new(Some(&salt), &full_ikm);
+        let mut out = [0 as u8; 48];
+        hk.expand(&key_info, &mut out).unwrap();
+        let fr = Fr::from_be_bytes_mod_order(&out);
+        if fr != Fr::zero() {
+            return fr;
+        }
+        hasher = Sha256::new();
+        hasher.update(&salt);
+        salt = hasher.finalize();
     }
 }
 

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -29,7 +29,6 @@ pub struct BLST;
 
 impl Engine for BLST {
     fn generate_tau(entropy: &Entropy) -> Tau {
-        // TODO: Use `blst_keygen` or one of its versions (EIP-2333).
         let fr = random_fr(*entropy.expose_secret());
         Secret::new((&fr).into())
     }

--- a/crypto/src/engine/blst/scalar.rs
+++ b/crypto/src/engine/blst/scalar.rs
@@ -1,7 +1,7 @@
 use crate::F;
 use blst::{
-    blst_fr, blst_fr_add, blst_fr_from_scalar, blst_fr_mul, blst_lendian_from_scalar, blst_scalar,
-    blst_scalar_from_be_bytes, blst_scalar_from_fr, blst_scalar_from_lendian,
+    blst_fr, blst_fr_add, blst_fr_from_scalar, blst_fr_mul, blst_keygen, blst_lendian_from_scalar,
+    blst_scalar, blst_scalar_from_fr, blst_scalar_from_lendian,
     blst_scalar_from_uint64,
 };
 use rand::{Rng, SeedableRng};
@@ -19,7 +19,13 @@ pub fn random_fr(entropy: [u8; 32]) -> blst_fr {
     let mut ret = blst_fr::default();
 
     unsafe {
-        blst_scalar_from_be_bytes(&mut scalar, buffer.as_ptr(), 32);
+        blst_keygen(
+            &mut scalar,
+            buffer.as_ptr(),
+            buffer.len(),
+            [0; 0].as_ptr(),
+            0,
+        );
         blst_fr_from_scalar(&mut ret, &scalar);
     }
 

--- a/crypto/src/engine/blst/scalar.rs
+++ b/crypto/src/engine/blst/scalar.rs
@@ -1,8 +1,7 @@
 use crate::F;
 use blst::{
     blst_fr, blst_fr_add, blst_fr_from_scalar, blst_fr_mul, blst_keygen, blst_lendian_from_scalar,
-    blst_scalar, blst_scalar_from_fr, blst_scalar_from_lendian,
-    blst_scalar_from_uint64,
+    blst_scalar, blst_scalar_from_fr, blst_scalar_from_lendian, blst_scalar_from_uint64,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;

--- a/crypto/src/engine/both.rs
+++ b/crypto/src/engine/both.rs
@@ -2,6 +2,7 @@ use super::Engine;
 use crate::{CeremonyError, Entropy, Tau, G1, G2};
 use rayon::join;
 use std::marker::PhantomData;
+use secrecy::ExposeSecret;
 
 /// Implementation of [`Engine`] that combines two existing engines for
 /// redundancy.
@@ -50,10 +51,8 @@ impl<A: Engine, B: Engine> Engine for Both<A, B> {
     }
 
     fn generate_tau(entropy: &Entropy) -> Tau {
-        let (a, _b) = join(|| A::generate_tau(entropy), || B::generate_tau(entropy));
-
-        // TODO: Standardize the derivation so we can check this
-        // assert_eq!(a.expose_secret(), b.expose_secret());
+        let (a, b) = join(|| A::generate_tau(entropy), || B::generate_tau(entropy));
+        assert_eq!(a.expose_secret(), b.expose_secret());
         a
     }
 

--- a/crypto/src/engine/both.rs
+++ b/crypto/src/engine/both.rs
@@ -1,8 +1,8 @@
 use super::Engine;
 use crate::{CeremonyError, Entropy, Tau, G1, G2};
 use rayon::join;
-use std::marker::PhantomData;
 use secrecy::ExposeSecret;
+use std::marker::PhantomData;
 
 /// Implementation of [`Engine`] that combines two existing engines for
 /// redundancy.

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -69,7 +69,8 @@ pub trait Engine {
 #[cfg(all(test, feature = "arkworks", feature = "blst"))]
 pub mod tests {
     use super::*;
-    use proptest::{proptest, strategy::Strategy};
+    use proptest::{arbitrary::any, proptest, strategy::Strategy};
+    use secrecy::ExposeSecret;
 
     pub fn arb_f() -> impl Strategy<Value = F> {
         arkworks::test::arb_fr().prop_map(F::from)
@@ -81,6 +82,20 @@ pub mod tests {
 
     pub fn arb_g2() -> impl Strategy<Value = G2> {
         arkworks::test::arb_g2().prop_map(G2::from)
+    }
+
+    pub fn arb_entropy() -> impl Strategy<Value = [u8; 32]> {
+        proptest::array::uniform32(any::<u8>())
+    }
+
+    #[test]
+    fn test_generate_tau() {
+        proptest!(|(entropy in arb_entropy())| {
+            let entropy = Secret::new(entropy);
+            let tau1 = Arkworks::generate_tau(&entropy);
+            let tau2 = BLST::generate_tau(&entropy);
+            assert_eq!(tau1.expose_secret(), tau2.expose_secret());
+        });
     }
 
     #[test]

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -22,7 +22,7 @@ use tracing::error;
 
 #[derive(Serialize)]
 pub struct ContributeReceipt {
-    receipt: String,
+    receipt:   String,
     signature: Signature,
 }
 
@@ -63,7 +63,8 @@ pub async fn contribute(
     Extension(num_contributions): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> Result<ContributeReceipt, ContributeError> {
-    // Handle the contribution in the background, so that request cancelation doesn't interrupt it.
+    // Handle the contribution in the background, so that request cancelation
+    // doesn't interrupt it.
     let res = tokio::spawn(async move {
         let id_token = lobby_state
             .begin_contributing(&session_id)
@@ -88,7 +89,7 @@ pub async fn contribute(
 
         let receipt = Receipt {
             identity: id_token.identity,
-            witness: contribution.receipt(),
+            witness:  contribution.receipt(),
         };
 
         let (signed_msg, signature) = receipt
@@ -134,7 +135,8 @@ pub async fn contribute_abort(
     Extension(storage): Extension<PersistentStorage>,
 ) -> Result<(), ContributeError> {
     // Abort the contribution in the background,
-    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state
+    // and storage calls.
     tokio::spawn(async move {
         lobby_state
             .abort_contribution(&session_id)
@@ -246,13 +248,10 @@ mod tests {
         let transcript_1 = {
             let mut transcript = transcript.clone();
             transcript
-                .verify_add::<Engine>(
-                    contribution_1.clone(),
-                    Identity::Github {
-                        id: 1234,
-                        username: "test_user".to_string(),
-                    },
-                )
+                .verify_add::<Engine>(contribution_1.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };
@@ -260,13 +259,10 @@ mod tests {
         let transcript_2 = {
             let mut transcript = transcript_1.clone();
             transcript
-                .verify_add::<Engine>(
-                    contribution_2.clone(),
-                    Identity::Github {
-                        id: 1234,
-                        username: "test_user".to_string(),
-                    },
-                )
+                .verify_add::<Engine>(contribution_2.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -82,7 +82,8 @@ pub async fn try_contribute(
         .unwrap_or(Err(TryContributeError::UnknownSessionId))?;
 
     // Attempt to set ourselves as the current contributor in the background,
-    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state
+    // and storage calls.
     tokio::spawn(async move {
         lobby_state.enter_lobby(&session_id).await?;
 


### PR DESCRIPTION
Fixes #136 and some outstanding TODOs. Uses `blst_keygen` for the BLST engine and a custom implementation of the CFRG spec for Arkworks. Finally allows us to compare the outputs of both engines.