### PR TITLE
Increase Code Coverage

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -18,7 +18,7 @@ jobs:
   accept:
     name: Accept
     runs-on: ubuntu-latest
-    needs: [lint, test, build_and_push, image_manifest]
+    needs: [ lint, test, build_and_push, image_manifest ]
     steps:
       - name: Accept
         run: true
@@ -114,7 +114,9 @@ jobs:
         with:
           key: cache-v1
       - name: Install cargo-binutils
-        run: cargo install cargo-binutils
+        run: |
+          cargo install cargo-binutils
+          cargo install cargo-tarpaulin
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -123,35 +125,9 @@ jobs:
         run: |
           openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out private.key
           openssl rsa -in private.key -pubout -out publickey.pem
-      - name: Build tests with coverage
+      - name: Generate code coverage
         run: |
-          cargo test --locked --workspace --all-features --all-targets --no-fail-fast --no-run
-          cargo test --locked --workspace --all-features --doc --no-fail-fast -- --help
-      - name: Run tests with coverage
-        run: |
-          cargo test --locked --workspace --all-features --all-targets --no-fail-fast -- --nocapture
-          cargo test --locked --workspace --all-features --doc --no-fail-fast
-      - name: Merge execution traces
-        run: cargo profdata -- merge -sparse $(find . -iname "profile-*.profraw") -o profile.profdata
-      - name: Export to lcov format for codecov
-        # See <https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/instrument-coverage.html#including-doc-tests>
-        run:
-          cargo cov -- export
-            --format=lcov > profile.lcov
-            --instr-profile=profile.profdata
-            $(
-              for file in
-                $(
-                  cargo test --locked --workspace --all-features --all-targets
-                    --no-fail-fast --no-run --message-format=json
-                    | jq -r "select(.profile.test == true) | .filenames[]"
-                    | grep -v dSYM -
-                )
-                target/debug/doctestbins/*/rust_out;
-              do
-                [[ -x $file ]] && printf "%s %s " -object $file ;
-              done
-            )
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --avoid-cfg-tarpaulin
       - name: Submit to codecov.io
         uses: codecov/codecov-action@v3.1.1
         with:
@@ -182,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [amd64, arm64]
+        platform: [ amd64, arm64 ]
     env:
       FEATURES: mimalloc
     steps:
@@ -244,7 +220,7 @@ jobs:
   image_manifest:
     name: Image manifest
     runs-on: ubuntu-latest
-    needs: [build_and_push]
+    needs: [ build_and_push ]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -268,7 +244,7 @@ jobs:
   push_to_docker:
     name: Push to Docker Hub
     runs-on: ubuntu-latest
-    needs: [image_manifest]
+    needs: [ image_manifest ]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -297,7 +273,7 @@ jobs:
   deploy_on_fly:
     name: Deploy on fly.io
     runs-on: ubuntu-latest
-    needs: [push_to_docker]
+    needs: [ push_to_docker ]
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -122,7 +122,7 @@ jobs:
           openssl rsa -in private.key -pubout -out publickey.pem
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --out Xml --avoid-cfg-tarpaulin
+          cargo tarpaulin --out Xml --avoid-cfg-tarpaulin --timeout 180 --features arkworks blst --workspace
       - name: Submit to codecov.io
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -116,17 +116,13 @@ jobs:
       - name: Install cargo-tarpaulin
         run: |
           cargo install cargo-tarpaulin
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
       - name: Generate RSA Test Keys
         run: |
           openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out private.key
           openssl rsa -in private.key -pubout -out publickey.pem
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --avoid-cfg-tarpaulin
+          cargo tarpaulin --verbose --all-features --out Xml --avoid-cfg-tarpaulin
       - name: Submit to codecov.io
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -113,9 +113,8 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           key: cache-v1
-      - name: Install cargo-binutils
+      - name: Install cargo-tarpaulin
         run: |
-          cargo install cargo-binutils
           cargo install cargo-tarpaulin
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ transcript.json
 .idea
 *.iml
 storage.db*
+*.profraw

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -69,6 +69,7 @@ fn derive_taus<E: Engine>(entropy: &Entropy, size: usize) -> Vec<Tau> {
         .collect()
 }
 
+#[allow(clippy::missing_panics_doc)] // Does not panic.
 #[must_use]
 pub fn get_pot_pubkeys<E: Engine>(entropy: &Entropy) -> Vec<G2> {
     let taus = derive_taus::<E>(entropy, 4);
@@ -127,10 +128,8 @@ pub mod tests {
             let result = get_pot_pubkeys::<DefaultEngine>(&secret);
             let taus = derive_taus::<DefaultEngine>(&secret, 4)
                 .into_iter()
-                .map(|tau| tau.expose_secret().clone())
-                .collect::<Vec<_>>();
+                .map(|tau| *tau.expose_secret());
             let expected: Vec<_> = taus
-                .into_iter()
                 .map(|tau| {
                     let fr = Fr::from(&tau);
                     let g2 = G2Affine::prime_subgroup_generator()
@@ -140,7 +139,7 @@ pub mod tests {
                 })
                 .collect();
             assert_eq!(result, expected);
-        })
+        });
     }
 }
 

--- a/crypto/src/batch_contribution.rs
+++ b/crypto/src/batch_contribution.rs
@@ -145,6 +145,7 @@ pub mod tests {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -103,6 +103,25 @@ impl BatchTranscript {
     }
 }
 
+#[cfg(test)]
+pub mod tests {
+    use crate::{
+        BatchTranscript, CeremoniesError::UnexpectedNumContributions, DefaultEngine, Identity,
+    };
+
+    #[test]
+    fn test_verify_add() {
+        let mut transcript = BatchTranscript::new([(2, 2), (3, 3)].iter());
+        let mut contrib = transcript.contribution();
+        contrib.contributions = contrib.contributions[0..1].to_vec();
+        let result = transcript
+            .verify_add::<DefaultEngine>(contrib, Identity::None)
+            .err()
+            .unwrap();
+        assert_eq!(result, UnexpectedNumContributions(2, 1));
+    }
+}
+
 #[cfg(feature = "bench")]
 #[cfg(not(tarpaulin_include))]
 #[doc(hidden)]

--- a/crypto/src/batch_transcript.rs
+++ b/crypto/src/batch_transcript.rs
@@ -104,6 +104,7 @@ impl BatchTranscript {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/contribution.rs
+++ b/crypto/src/contribution.rs
@@ -54,8 +54,73 @@ impl Contribution {
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use super::*;
+    use crate::{
+        group::tests::{invalid_g1, invalid_g2},
+        DefaultEngine, G1,
+    };
+
+    pub fn valid_contribution() -> Contribution {
+        Contribution {
+            powers:        Powers {
+                g1: vec![G1::one()],
+                g2: vec![G2::one()],
+            },
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
+        }
+    }
+
+    pub fn invalid_g1_contribution() -> Contribution {
+        Contribution {
+            powers:        Powers {
+                g1: vec![invalid_g1()],
+                g2: vec![G2::one()],
+            },
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
+        }
+    }
+
+    pub fn invalid_g2_contribution() -> Contribution {
+        Contribution {
+            powers:        Powers {
+                g1: vec![G1::one()],
+                g2: vec![invalid_g2()],
+            },
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
+        }
+    }
+
+    pub fn invalid_pot_pubkey_contribution() -> Contribution {
+        Contribution {
+            powers:        Powers {
+                g1: vec![G1::one()],
+                g2: vec![G2::one()],
+            },
+            pot_pubkey:    invalid_g2(),
+            bls_signature: BlsSignature::empty(),
+        }
+    }
+
+    #[test]
+    fn test_validate() {
+        assert!(matches!(
+            invalid_g1_contribution().validate::<DefaultEngine>(),
+            Err(CeremonyError::InvalidG1Power(_, _))
+        ));
+        assert!(matches!(
+            invalid_g2_contribution().validate::<DefaultEngine>(),
+            Err(CeremonyError::InvalidG2Power(_, _))
+        ));
+        assert!(matches!(
+            invalid_pot_pubkey_contribution().validate::<DefaultEngine>(),
+            Err(CeremonyError::InvalidG2Power(_, _))
+        ));
+        assert!(valid_contribution().validate::<DefaultEngine>().is_ok());
+    }
 
     #[test]
     fn contribution_json() {

--- a/crypto/src/engine/arkworks/endomorphism.rs
+++ b/crypto/src/engine/arkworks/endomorphism.rs
@@ -259,6 +259,7 @@ pub mod test {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::{

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -299,6 +299,7 @@ pub mod test {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::{super::bench::bench_engine, *};

--- a/crypto/src/engine/arkworks/mod.rs
+++ b/crypto/src/engine/arkworks/mod.rs
@@ -256,7 +256,7 @@ fn bls_keygen(ikm: [u8; 64]) -> Fr {
             return fr;
         }
         hasher = Sha256::new();
-        hasher.update(&salt);
+        hasher.update(salt);
         salt = hasher.finalize();
     }
 }

--- a/crypto/src/engine/arkworks/zcash_format.rs
+++ b/crypto/src/engine/arkworks/zcash_format.rs
@@ -216,6 +216,7 @@ mod test {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -295,6 +295,7 @@ mod tests {
 }
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::{super::bench::bench_engine, *};

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -279,13 +279,18 @@ fn random_factors(n: usize) -> (Vec<blst_scalar>, blst_scalar) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::arkworks::bench::{rand_g1, rand_g2};
+    use crate::engine::{
+        tests::arb_g1,
+    };
+    use proptest::proptest;
+    use crate::engine::tests::arb_g2;
 
     #[test]
     fn test_verify_g1() {
-        let powers = [rand_g1().into()];
-        let tau = rand_g2().into();
-        let _ = BLST::verify_g1(&powers, tau);
+        proptest!(|(g1 in arb_g1(), g2 in arb_g2())| {
+            let powers = [g1];
+            let _ = BLST::verify_g1(&powers, g2).unwrap();
+        })
     }
 }
 

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -285,8 +285,8 @@ mod tests {
     fn test_verify_g1() {
         proptest!(|(g1 in arb_g1(), g2 in arb_g2())| {
             let powers = [g1];
-            let _ = BLST::verify_g1(&powers, g2).unwrap();
-        })
+            BLST::verify_g1(&powers, g2).unwrap();
+        });
     }
 }
 

--- a/crypto/src/engine/blst/mod.rs
+++ b/crypto/src/engine/blst/mod.rs
@@ -279,11 +279,8 @@ fn random_factors(n: usize) -> (Vec<blst_scalar>, blst_scalar) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::{
-        tests::arb_g1,
-    };
+    use crate::engine::tests::{arb_g1, arb_g2};
     use proptest::proptest;
-    use crate::engine::tests::arb_g2;
 
     #[test]
     fn test_verify_g1() {

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -70,6 +70,11 @@ pub trait Engine {
 pub mod tests {
     use super::*;
     use proptest::{proptest, strategy::Strategy};
+    use proptest::arbitrary::any;
+
+    pub fn arb_entropy() -> impl Strategy<Value = [u8; 32]> {
+        proptest::array::uniform32(any::<u8>())
+    }
 
     pub fn arb_f() -> impl Strategy<Value = F> {
         arkworks::test::arb_fr().prop_map(F::from)

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -130,7 +130,7 @@ pub mod tests {
     }
 }
 
-#[cfg(feature = "bench")]
+#[cfg(all(feature = "bench", not(tarpaulin_include)))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -130,7 +130,8 @@ pub mod tests {
     }
 }
 
-#[cfg(all(feature = "bench", not(tarpaulin_include)))]
+#[cfg(feature = "bench")]
+#[no_coverage]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -131,7 +131,7 @@ pub mod tests {
 }
 
 #[cfg(feature = "bench")]
-#[no_coverage]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/engine/mod.rs
+++ b/crypto/src/engine/mod.rs
@@ -69,8 +69,7 @@ pub trait Engine {
 #[cfg(all(test, feature = "arkworks", feature = "blst"))]
 pub mod tests {
     use super::*;
-    use proptest::{proptest, strategy::Strategy};
-    use proptest::arbitrary::any;
+    use proptest::{arbitrary::any, proptest, strategy::Strategy};
 
     pub fn arb_entropy() -> impl Strategy<Value = [u8; 32]> {
         proptest::array::uniform32(any::<u8>())

--- a/crypto/src/group.rs
+++ b/crypto/src/group.rs
@@ -106,11 +106,11 @@ impl<'de> Deserialize<'de> for G2 {
 pub mod tests {
     use crate::{G1, G2};
 
-    pub fn invalid_g1() -> G1 {
-        return G1([0; 48]);
+    pub const fn invalid_g1() -> G1 {
+        G1([0; 48])
     }
 
-    pub fn invalid_g2() -> G2 {
-        return G2([0; 96]);
+    pub const fn invalid_g2() -> G2 {
+        G2([0; 96])
     }
 }

--- a/crypto/src/group.rs
+++ b/crypto/src/group.rs
@@ -101,3 +101,16 @@ impl<'de> Deserialize<'de> for G2 {
         hex_to_bytes(deserializer).map(Self)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use crate::{G1, G2};
+
+    pub fn invalid_g1() -> G1 {
+        return G1([0; 48]);
+    }
+
+    pub fn invalid_g2() -> G2 {
+        return G2([0; 96]);
+    }
+}

--- a/crypto/src/hex_format.rs
+++ b/crypto/src/hex_format.rs
@@ -50,9 +50,9 @@ pub enum HexDecodingError {
 }
 
 impl HexDecodingError {
-    pub fn to_de_error<'de, E: de::Error>(self, visitor: impl de::Visitor<'de>) -> E {
+    pub fn into_de_error<'de, E: de::Error>(self, visitor: &'_ impl de::Visitor<'de>) -> E {
         match self {
-            InvalidLength(len) => E::invalid_length(len, &visitor),
+            InvalidLength(len) => E::invalid_length(len, visitor),
             _ => E::custom(self),
         }
     }
@@ -115,7 +115,7 @@ impl<'de, const N: usize> de::Visitor<'de> for OptionalHexStrVisitor<N> {
             Ok(None)
         } else {
             hex_str_to_bytes::<N>(v)
-                .map_err(|e| e.to_de_error(self))
+                .map_err(|e| e.into_de_error(&self))
                 .map(Some)
         }
     }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -44,6 +44,7 @@ pub type DefaultEngine = Arkworks;
 pub type DefaultEngine = BLST;
 
 #[cfg(feature = "bench")]
+#[cfg(not(tarpaulin_include))]
 #[doc(hidden)]
 pub mod bench {
     use super::*;

--- a/crypto/src/powers.rs
+++ b/crypto/src/powers.rs
@@ -89,7 +89,7 @@ mod tests {
         let result = serde_json::from_value::<super::Powers>(wrong_number_g1_powers)
             .err()
             .unwrap();
-        assert!(format!("{}", result).contains("Inconsistent number of G1 powers"));
+        assert!(format!("{result}").contains("Inconsistent number of G1 powers"));
 
         let wrong_number_g2_powers = json!({
             "numG1Powers": 1,
@@ -102,6 +102,6 @@ mod tests {
         let result = serde_json::from_value::<super::Powers>(wrong_number_g2_powers)
             .err()
             .unwrap();
-        assert!(format!("{}", result).contains("Inconsistent number of G2 powers"));
+        assert!(format!("{result}").contains("Inconsistent number of G2 powers"));
     }
 }

--- a/crypto/src/powers.rs
+++ b/crypto/src/powers.rs
@@ -69,3 +69,39 @@ impl Powers {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn test_invalid_powers_json() {
+        let g1 = "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let g2 = "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let wrong_number_g1_powers = json!({
+            "numG1Powers": 1,
+            "numG2Powers": 1,
+            "powersOfTau": {
+                "G1Powers": [g1, g1],
+                "G2Powers": [g2],
+            },
+        });
+        let result = serde_json::from_value::<super::Powers>(wrong_number_g1_powers)
+            .err()
+            .unwrap();
+        assert!(format!("{}", result).contains("Inconsistent number of G1 powers"));
+
+        let wrong_number_g2_powers = json!({
+            "numG1Powers": 1,
+            "numG2Powers": 1,
+            "powersOfTau": {
+                "G1Powers": [g1],
+                "G2Powers": [g2, g2],
+            },
+        });
+        let result = serde_json::from_value::<super::Powers>(wrong_number_g2_powers)
+            .err()
+            .unwrap();
+        assert!(format!("{}", result).contains("Inconsistent number of G2 powers"));
+    }
+}

--- a/crypto/src/signature/identity.rs
+++ b/crypto/src/signature/identity.rs
@@ -149,6 +149,8 @@ mod tests {
         let identity = Identity::None;
         assert_eq!(identity.to_string(), "");
         assert_eq!(identity, "".parse().unwrap());
+        assert_eq!(identity.provider_name(), "None");
+        assert_eq!(identity.nickname(), "<<unauthorized>>");
     }
 
     #[test]
@@ -164,6 +166,21 @@ mod tests {
                 .parse()
                 .unwrap()
         );
+        assert_eq!(
+            "eth|D".parse::<Identity>().err().unwrap(),
+            IdentityError::InvalidEthereumAddress
+        );
+        assert_eq!(
+            "eth|0xD".parse::<Identity>().err().unwrap(),
+            IdentityError::InvalidEthereumAddress
+        );
+        assert_eq!(
+            "eth|0x0000000000000000000000000000000000000000|"
+                .parse::<Identity>()
+                .err()
+                .unwrap(),
+            IdentityError::TooManyFields
+        );
     }
 
     #[test]
@@ -174,5 +191,21 @@ mod tests {
         };
         assert_eq!(identity.to_string(), "git|123|username");
         assert_eq!(identity, "git|123|username".parse().unwrap());
+        assert_eq!(
+            "git|123|username|".parse::<Identity>().err().unwrap(),
+            IdentityError::TooManyFields
+        );
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert_eq!(
+            "|".parse::<Identity>().err().unwrap(),
+            IdentityError::TooManyFields
+        );
+        assert_eq!(
+            "google|".parse::<Identity>().err().unwrap(),
+            IdentityError::UnsupportedType
+        );
     }
 }

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -182,13 +182,11 @@ mod test {
             pot_pubkey:    G2::zero(),
             bls_signature: BlsSignature::empty(),
         };
-        assert_eq!(
-            transcript
-                .verify::<DefaultEngine>(&bad_g1_contribution)
-                .err()
-                .unwrap(),
-            InvalidG1Power(0, InvalidSubgroup)
-        );
+        let result = transcript
+            .verify::<DefaultEngine>(&bad_g1_contribution)
+            .err()
+            .unwrap();
+        assert!(matches!(result, InvalidG1Power(_, InvalidSubgroup)));
     }
 
     #[test]
@@ -204,13 +202,11 @@ mod test {
             pot_pubkey:    G2::zero(),
             bls_signature: BlsSignature::empty(),
         };
-        assert_eq!(
-            transcript
-                .verify::<DefaultEngine>(&bad_g2_contribution)
-                .err()
-                .unwrap(),
-            InvalidG2Power(0, InvalidSubgroup)
-        );
+        let result = transcript
+            .verify::<DefaultEngine>(&bad_g2_contribution)
+            .err()
+            .unwrap();
+        assert!(matches!(result, InvalidG2Power(_, InvalidSubgroup)));
     }
 
     #[test]
@@ -268,12 +264,12 @@ mod test {
             .mul(Fr::from(2))
             .into_affine();
         let contribution = Contribution {
-            powers:     Powers {
+            powers:        Powers {
                 // Pretend Tau is 2, but make the third element g1^3 instead of g1^4.
                 g1: vec![G1::from(g1_1), G1::from(g1_2), G1::from(g1_3)],
                 g2: vec![G2::from(g2_1), G2::from(g2_2)],
             },
-            pot_pubkey: G2::from(g2_2),
+            pot_pubkey:    G2::from(g2_2),
             bls_signature: BlsSignature::empty(),
         };
         assert_eq!(

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -126,6 +126,7 @@ mod test {
     use crate::{
         CeremonyError::{
             G1PairingFailed, G2PairingFailed, InvalidG1Power, InvalidG2Power, PubKeyPairingFailed,
+            UnexpectedNumG1Powers, UnexpectedNumG2Powers,
         },
         DefaultEngine,
         ParseError::InvalidSubgroup,
@@ -314,5 +315,29 @@ mod test {
                 .unwrap(),
             G2PairingFailed
         );
+    }
+
+    #[test]
+    fn test_verify_wrong_g1_point_count() {
+        let transcript = Transcript::new(3, 3);
+        let mut contribution = transcript.contribution();
+        contribution.powers.g1 = contribution.powers.g1[0..2].to_vec();
+        let result = transcript
+            .verify::<DefaultEngine>(&contribution)
+            .err()
+            .unwrap();
+        assert_eq!(result, UnexpectedNumG1Powers(3, 2));
+    }
+
+    #[test]
+    fn test_verify_wrong_g2_point_count() {
+        let transcript = Transcript::new(3, 3);
+        let mut contribution = transcript.contribution();
+        contribution.powers.g2 = contribution.powers.g2[0..2].to_vec();
+        let result = transcript
+            .verify::<DefaultEngine>(&contribution)
+            .err()
+            .unwrap();
+        assert_eq!(result, UnexpectedNumG2Powers(3, 2));
     }
 }

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -123,6 +123,15 @@ impl Transcript {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{
+        CeremonyError::{G1PairingFailed, InvalidG1Power, InvalidG2Power, PubKeyPairingFailed},
+        DefaultEngine,
+        ParseError::InvalidSubgroup,
+    };
+    use ark_bls12_381::{Fr, G1Affine, G2Affine};
+    use ark_ec::{AffineCurve, ProjectiveCurve};
+    use hex_literal::hex;
+    use crate::CeremonyError::G2PairingFailed;
 
     #[test]
     fn transcript_json() {
@@ -158,5 +167,152 @@ mod test {
         );
         let deser = serde_json::from_value::<Transcript>(json).unwrap();
         assert_eq!(deser, t);
+    }
+
+    #[test]
+    fn test_verify_g1_not_in_subgroup() {
+        let transcript = Transcript::new(2, 2);
+        let point_not_in_g1 = G1(hex!("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+        let bad_g1_contribution = Contribution {
+            powers:        Powers {
+                g1: vec![point_not_in_g1, point_not_in_g1],
+                g2: vec![G2::zero(), G2::zero()],
+            },
+            pot_pubkey:    G2::zero(),
+            bls_signature: BlsSignature::empty(),
+        };
+        assert_eq!(
+            transcript
+                .verify::<DefaultEngine>(&bad_g1_contribution)
+                .err()
+                .unwrap(),
+            InvalidG1Power(0, InvalidSubgroup)
+        );
+    }
+
+    #[test]
+    fn test_verify_g2_not_in_subgroup() {
+        let transcript = Transcript::new(2, 2);
+        let point_not_in_g2 = G2(hex!("a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"));
+
+        let bad_g2_contribution = Contribution {
+            powers:        Powers {
+                g1: vec![G1::zero(), G1::zero()],
+                g2: vec![point_not_in_g2, point_not_in_g2],
+            },
+            pot_pubkey:    G2::zero(),
+            bls_signature: BlsSignature::empty(),
+        };
+        assert_eq!(
+            transcript
+                .verify::<DefaultEngine>(&bad_g2_contribution)
+                .err()
+                .unwrap(),
+            InvalidG2Power(0, InvalidSubgroup)
+        );
+    }
+
+    #[test]
+    fn test_verify_wrong_pubkey() {
+        let transcript = Transcript::new(2, 2);
+
+        let secret = Fr::from(42);
+        let bad_secret = Fr::from(43);
+        let g1_gen = G1::from(G1Affine::prime_subgroup_generator());
+        let g1_elem = G1::from(
+            G1Affine::prime_subgroup_generator()
+                .mul(secret)
+                .into_affine(),
+        );
+        let g2_gen = G2::from(G2Affine::prime_subgroup_generator());
+        let g2_elem = G2::from(
+            G2Affine::prime_subgroup_generator()
+                .mul(secret)
+                .into_affine(),
+        );
+        let pubkey = G2::from(
+            G2Affine::prime_subgroup_generator()
+                .mul(bad_secret)
+                .into_affine(),
+        );
+        let bad_pot_pubkey = Contribution {
+            powers:        Powers {
+                g1: vec![g1_gen, g1_elem],
+                g2: vec![g2_gen, g2_elem],
+            },
+            pot_pubkey:    pubkey,
+            bls_signature: BlsSignature::empty(),
+        };
+        assert_eq!(
+            transcript
+                .verify::<DefaultEngine>(&bad_pot_pubkey)
+                .err()
+                .unwrap(),
+            PubKeyPairingFailed
+        )
+    }
+
+    #[test]
+    fn test_verify_wrong_g1_powers() {
+        let transcript = Transcript::new(3, 2);
+        let g1_1 = G1Affine::prime_subgroup_generator()
+            .mul(Fr::from(1))
+            .into_affine();
+        let g1_2 = G1Affine::prime_subgroup_generator()
+            .mul(Fr::from(2))
+            .into_affine();
+        let g1_3 = G1Affine::prime_subgroup_generator()
+            .mul(Fr::from(3))
+            .into_affine();
+        let contribution = Contribution {
+            powers:        Powers {
+                // Pretend Tau is 2, but make the third element g1^3 instead of g1^4.
+                g1: vec![G1::from(g1_1), G1::from(g1_2), G1::from(g1_3)],
+                g2: vec![G2::one(), G2::one()],
+            },
+            pot_pubkey:    G2::from(
+                G2Affine::prime_subgroup_generator()
+                    .mul(Fr::from(2))
+                    .into_affine(),
+            ),
+            bls_signature: BlsSignature::empty(),
+        };
+        assert_eq!(
+            transcript
+                .verify::<DefaultEngine>(&contribution)
+                .err()
+                .unwrap(),
+            G1PairingFailed
+        );
+    }
+
+    #[test]
+    fn test_verify_wrong_g2_powers() {
+        let transcript = Transcript::new(2, 3);
+        let g2_1 = G2Affine::prime_subgroup_generator()
+            .mul(Fr::from(1))
+            .into_affine();
+        let g2_2 = G2Affine::prime_subgroup_generator()
+            .mul(Fr::from(2))
+            .into_affine();
+        let g2_3 = G2Affine::prime_subgroup_generator()
+            .mul(Fr::from(3))
+            .into_affine();
+        let contribution = Contribution {
+            powers:        Powers {
+                g1: vec![G1::one(), G1::one()],
+                // Pretend Tau is 2, but make the third element g2^3 instead of g2^4.
+                g2: vec![G2::from(g2_1), G2::from(g2_2), G2::from(g2_3)],
+            },
+            pot_pubkey:    G2::one(),
+            bls_signature: BlsSignature::empty(),
+        };
+        assert_eq!(
+            transcript
+                .verify::<DefaultEngine>(&contribution)
+                .err()
+                .unwrap(),
+            G2PairingFailed
+        );
     }
 }

--- a/crypto/src/transcript.rs
+++ b/crypto/src/transcript.rs
@@ -247,7 +247,7 @@ mod test {
                 .err()
                 .unwrap(),
             PubKeyPairingFailed
-        )
+        );
     }
 
     #[test]

--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -135,9 +135,9 @@ pub async fn auth_client_link(
     Extension(eth_client): Extension<EthOAuthClient>,
     Extension(gh_client): Extension<GithubOAuthClient>,
 ) -> Result<AuthUrl, AuthErrorPayload> {
-    let lobby_size = lobby_state.get_lobby_size().await;
+    let session_count = lobby_state.get_session_count().await;
 
-    if lobby_size >= options.lobby.max_lobby_size {
+    if session_count >= options.lobby.max_sessions_count {
         return Err(AuthErrorPayload::LobbyIsFull);
     }
 
@@ -482,4 +482,12 @@ async fn post_authenticate(
         session_id: session_id.to_string(),
         as_redirect_to: redirect_to,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
 }

--- a/src/api/v1/contribute.rs
+++ b/src/api/v1/contribute.rs
@@ -22,7 +22,7 @@ use tracing::error;
 
 #[derive(Serialize)]
 pub struct ContributeReceipt {
-    receipt: String,
+    receipt:   String,
     signature: Signature,
 }
 
@@ -63,7 +63,8 @@ pub async fn contribute(
     Extension(num_contributions): Extension<SharedCeremonyStatus>,
     Extension(keys): Extension<SharedKeys>,
 ) -> Result<ContributeReceipt, ContributeError> {
-    // Handle the contribution in the background, so that request cancelation doesn't interrupt it.
+    // Handle the contribution in the background, so that request cancelation
+    // doesn't interrupt it.
     let res = tokio::spawn(async move {
         let id_token = lobby_state
             .begin_contributing(&session_id)
@@ -88,7 +89,7 @@ pub async fn contribute(
 
         let receipt = Receipt {
             identity: id_token.identity,
-            witness: contribution.receipt(),
+            witness:  contribution.receipt(),
         };
 
         let (signed_msg, signature) = receipt
@@ -134,7 +135,8 @@ pub async fn contribute_abort(
     Extension(storage): Extension<PersistentStorage>,
 ) -> Result<(), ContributeError> {
     // Abort the contribution in the background,
-    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state
+    // and storage calls.
     tokio::spawn(async move {
         lobby_state
             .abort_contribution(&session_id)
@@ -246,13 +248,10 @@ mod tests {
         let transcript_1 = {
             let mut transcript = transcript.clone();
             transcript
-                .verify_add::<Engine>(
-                    contribution_1.clone(),
-                    Identity::Github {
-                        id: 1234,
-                        username: "test_user".to_string(),
-                    },
-                )
+                .verify_add::<Engine>(contribution_1.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };
@@ -260,13 +259,10 @@ mod tests {
         let transcript_2 = {
             let mut transcript = transcript_1.clone();
             transcript
-                .verify_add::<Engine>(
-                    contribution_2.clone(),
-                    Identity::Github {
-                        id: 1234,
-                        username: "test_user".to_string(),
-                    },
-                )
+                .verify_add::<Engine>(contribution_2.clone(), Identity::Github {
+                    id:       1234,
+                    username: "test_user".to_string(),
+                })
                 .unwrap();
             transcript
         };

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -82,7 +82,8 @@ pub async fn try_contribute(
         .unwrap_or(Err(TryContributeError::UnknownSessionId))?;
 
     // Attempt to set ourselves as the current contributor in the background,
-    // so that request cancelation doesn't interrupt it inbetween the lobby_state and storage calls.
+    // so that request cancelation doesn't interrupt it inbetween the lobby_state
+    // and storage calls.
     tokio::spawn(async move {
         lobby_state.enter_lobby(&session_id).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,6 @@ pub async fn start_server(
     ));
 
     let app = Router::new()
-        .route("/hello_world", get(hello_world))
         .route("/auth/request_link", get(auth_client_link))
         .route("/auth/callback/github", get(github_callback))
         .route("/auth/callback/eth", get(eth_callback))
@@ -185,11 +184,6 @@ pub async fn start_server(
         );
     let server = Server::try_bind(&addr)?.serve(app.into_make_service());
     Ok(server)
-}
-
-#[allow(clippy::unused_async)] // Required for axum function signature
-async fn hello_world() -> Html<&'static str> {
-    Html("<h1>Server is Running</h1>")
 }
 
 #[allow(clippy::unused_async)] // Required for axum function signature

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -207,6 +207,10 @@ impl SharedLobbyState {
         self.inner.lock().await.sessions_in_lobby.len()
     }
 
+    pub async fn get_session_count(&self) -> usize {
+        self.inner.lock().await.sessions_out_of_lobby.len()
+    }
+
     pub async fn insert_session(
         &self,
         session_id: SessionId,

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -301,3 +301,19 @@ pub fn assert_includes_contribution(
             }
         })
 }
+
+pub async fn get_transcript(harness: &Harness, client: &reqwest::Client) -> BatchTranscript {
+    let response = client
+        .get(harness.app_path("info/current_state"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let from_app = response
+        .json::<BatchTranscript>()
+        .await
+        .expect("must be a valid transcript");
+    let from_file = harness.read_transcript_file().await;
+    assert_eq!(from_app, from_file);
+    from_app
+}

--- a/tests/common/actions.rs
+++ b/tests/common/actions.rs
@@ -196,11 +196,10 @@ pub async fn contribute_successfully(
 ) {
     let response = request_contribute(harness, http_client, session_id, contribution).await;
 
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "Response must be successful"
-    );
+    if response.status() != StatusCode::OK {
+        println!("Response: {:?}", response.text().await);
+        panic!("Response must be successful");
+    }
 
     let response_json = response
         .json::<Value>()

--- a/tests/common/participants.rs
+++ b/tests/common/participants.rs
@@ -1,4 +1,7 @@
-use crate::{actions, actions::entropy_from_str, AnyTestUser, Harness, TestUser};
+use crate::{
+    actions, actions::entropy_from_str, common::mock_auth_service::EthUser, AnyTestUser, Harness,
+    TestUser,
+};
 use ethers_core::types::Signature;
 use ethers_signers::Signer;
 use http::StatusCode;
@@ -50,7 +53,7 @@ pub async fn well_behaved(
         )
         .expect("Adding entropy must be possible");
 
-    if let AnyTestUser::Eth(wallet) = &user.user {
+    if let AnyTestUser::Eth(EthUser { wallet, .. }) = &user.user {
         contribution.ecdsa_signature = EcdsaSignature(Some(
             wallet
                 .sign_typed_data(&signature::ContributionTypedData::from(&contribution))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,12 +1,9 @@
 #![cfg(test)]
 
-use crate::{
-    actions::assert_includes_contribution,
-    common::{
-        actions, harness,
-        harness::{run_test_harness, Harness},
-        mock_auth_service::{AnyTestUser, GhUser, TestUser},
-    },
+use crate::common::{
+    actions, harness,
+    harness::{run_test_harness, Harness},
+    mock_auth_service::{AnyTestUser, GhUser, TestUser},
 };
 use common::participants;
 use ethers_core::types::Address;
@@ -474,7 +471,7 @@ async fn test_wrong_ecdsa_signature() {
 
     let transcript = harness.read_transcript_file().await;
 
-    assert_includes_contribution(&transcript, &contribution, &user, false, true)
+    actions::assert_includes_contribution(&transcript, &contribution, &user, false, true)
 }
 
 #[tokio::test]
@@ -504,7 +501,7 @@ async fn test_wrong_bls_signature() {
 
     let transcript = harness.read_transcript_file().await;
 
-    assert_includes_contribution(&transcript, &contribution, &user, false, false)
+    actions::assert_includes_contribution(&transcript, &contribution, &user, false, false)
 }
 
 #[tokio::test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -373,13 +373,13 @@ async fn test_large_lobby_with_slow_compute_users() {
 
 #[tokio::test]
 async fn test_various_contributors() {
-    let harness = Arc::new(
-        Builder::new()
-            .set_compute_deadline(Duration::from_millis(4000))
-            .set_lobby_checkin_frequency(Duration::from_millis(2000))
-            .set_lobby_checkin_tolerance(Duration::from_millis(2000))
-            .run(),
-    );
+    let harness = Builder::new()
+        .set_compute_deadline(Duration::from_millis(4000))
+        .set_lobby_checkin_frequency(Duration::from_millis(2000))
+        .set_lobby_checkin_tolerance(Duration::from_millis(2000))
+        .run()
+        .await;
+    let harness = Arc::new(harness);
     let client = Arc::new(reqwest::Client::new());
     let n = 40;
     let handles = (0..n).into_iter().map(|i| {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -151,6 +151,20 @@ async fn test_too_new_accounts() {
 }
 
 #[tokio::test]
+async fn test_nonexistent_eth_user() {
+    let harness = run_test_harness().await;
+    let http_client = reqwest::Client::new();
+    let csrf = actions::get_and_validate_csrf_token(&harness, None).await;
+    let response = http_client
+        .get(harness.app_path("auth/callback/eth"))
+        .query(&[("state", csrf), ("code", "1234".to_string())])
+        .send()
+        .await
+        .expect("Could not call the endpoint");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn test_gh_auth_with_custom_frontend_redirect() {
     let harness = run_test_harness().await;
     let client = reqwest::Client::builder()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -527,7 +527,7 @@ async fn test_various_contributors() {
     });
 
     let post_conditions = futures::future::join_all(handles).await;
-    let final_transcript = harness.read_transcript_file().await;
+    let final_transcript = actions::get_transcript(harness.as_ref(), client.as_ref()).await;
     post_conditions
         .into_iter()
         .map(|r| r.expect("must terminate successfully"))
@@ -600,7 +600,7 @@ async fn test_wrong_ecdsa_signature() {
     )
     .await;
 
-    let transcript = harness.read_transcript_file().await;
+    let transcript = actions::get_transcript(&harness, &http_client).await;
 
     actions::assert_includes_contribution(&transcript, &contribution, &user, false, true)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{
     actions, harness,
-    harness::{run_test_harness, Harness},
+    harness::{run_test_harness, Builder, Harness},
     mock_auth_service::{AnyTestUser, GhUser, TestUser},
 };
 use common::participants;
@@ -373,7 +373,13 @@ async fn test_large_lobby_with_slow_compute_users() {
 
 #[tokio::test]
 async fn test_various_contributors() {
-    let harness = Arc::new(run_test_harness().await);
+    let harness = Arc::new(
+        Builder::new()
+            .set_compute_deadline(Duration::from_millis(4000))
+            .set_lobby_checkin_frequency(Duration::from_millis(2000))
+            .set_lobby_checkin_tolerance(Duration::from_millis(2000))
+            .run(),
+    );
     let client = Arc::new(reqwest::Client::new());
     let n = 40;
     let handles = (0..n).into_iter().map(|i| {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -252,6 +252,9 @@ async fn test_double_contribution() {
 async fn test_double_contribution_when_allowed() {
     let harness = harness::Builder::new()
         .allow_multi_contribution()
+        .set_lobby_checkin_frequency(Duration::from_secs(2))
+        .set_lobby_checkin_tolerance(Duration::from_secs(2))
+        .set_compute_deadline(Duration::from_secs(4))
         .run()
         .await;
     let http_client = reqwest::Client::new();


### PR DESCRIPTION
This fixes code coverage reporting (using line based cov now) and aims to get coverage as high as possible and feasible. 100% is impossible to achieve, due to bugs in the reporter and technically untestable paths (impossible errors in libraries, deep failures). This work is concluded based on a manual review of all uncovered lines (see report: https://app.codecov.io/gh/ethereum/kzg-ceremony-sequencer/tree/wip%2Fmk%2Ftestcov/). The final coverage number for this branch is 87.81%.

Fixes #138