### PR TITLE
Allow calling try_contribute again while awaiting a contribution

### DIFF
--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -82,20 +82,19 @@ pub async fn try_contribute(
         })
         .await;
 
-    let uid = match res {
-        Some(inner) => inner?,
-        None => {
-            // Session not found. Check if they're the active contributor, and
-            // if so, if we can give them back the contribution base they need.
-            lobby_state
-                .request_contribution_file_again(&session_id)
-                .await?;
+    let uid = if let Some(inner) = res {
+        inner?
+    } else {
+        // Session not found. Check if they're the active contributor, and
+        // if so, if we can give them back the contribution base they need.
+        lobby_state
+            .request_contribution_file_again(&session_id)
+            .await?;
 
-            let transcript = transcript.read().await;
-            return Ok(TryContributeResponse {
-                contribution: transcript.contribution(),
-            });
-        }
+        let transcript = transcript.read().await;
+        return Ok(TryContributeResponse {
+            contribution: transcript.contribution(),
+        });
     };
 
     // Attempt to set ourselves as the current contributor in the background,

--- a/src/api/v1/lobby.rs
+++ b/src/api/v1/lobby.rs
@@ -48,7 +48,7 @@ impl From<ActiveContributorError> for TryContributeError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TryContributeResponse<C> {
     contribution: C,
 }

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -46,7 +46,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn min_checkin_delay(&self) -> Duration {
+    pub const fn min_checkin_delay(&self) -> Duration {
         self.lobby_checkin_frequency
             .saturating_sub(self.lobby_checkin_tolerance)
     }
@@ -316,12 +316,11 @@ impl SharedLobbyState {
         } = &mut lobby_state.active_contributor
         {
             if &session.id == session_id {
-                if last_requested.elapsed() >= self.options.min_checkin_delay() {
-                    *last_requested = Instant::now();
-                    return ReRequestTranscriptResult::Allowed;
-                } else {
+                if last_requested.elapsed() < self.options.min_checkin_delay() {
                     return ReRequestTranscriptResult::RateLimited;
                 }
+                *last_requested = Instant::now();
+                return ReRequestTranscriptResult::Allowed;
             }
         }
         ReRequestTranscriptResult::NotAwaitingContribution

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -58,6 +58,7 @@ pub struct SessionInfoWithId {
     info: SessionInfo,
 }
 
+#[derive(Debug)]
 pub enum ActiveContributor {
     None,
     AwaitingContribution(SessionInfoWithId),
@@ -281,6 +282,14 @@ impl SharedLobbyState {
 
             drop(state);
             storage.expire_contribution(&participant.0).await.unwrap();
+        }
+    }
+
+    pub async fn is_awaiting_contribution_from(&self, session_id: &SessionId) -> bool {
+        let lobby_state = self.inner.lock().await;
+        match &lobby_state.active_contributor {
+            ActiveContributor::AwaitingContribution(contributor) => &contributor.id == session_id,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
This PR adds a check to try_contribute to check if we're currently awaiting a contribution from this session, and if so, it just sends back the contribution request again. This means that e.g. if someone's internet cuts out while calling try_contribute, they can just call it again and successfully complete the ceremony. I've also added a test of this :) 