### PR TITLE
Move idle users out of the lobby instead of logging them out

### DIFF
--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -194,6 +194,7 @@ impl SharedLobbyState {
         state.active_contributor = ActiveContributor::None;
     }
 
+    #[allow(clippy::needless_collect)]
     pub async fn clear_lobby(&self, predicate: impl Fn(&SessionInfo) -> bool + Copy + Send) {
         let mut lobby_state = self.inner.lock().await;
         let sessions_to_remove = lobby_state
@@ -214,9 +215,9 @@ impl SharedLobbyState {
                 Some((id, info))
             })
             .collect::<Vec<_>>();
-        removed_sessions.into_iter().for_each(|(id, info)| {
+        for (id, info) in removed_sessions {
             lobby_state.sessions_out_of_lobby.insert(id, info);
-        });
+        }
     }
 
     pub async fn clear_session(&self, predicate: impl Fn(&SessionInfo) -> bool + Send) {

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -200,13 +200,7 @@ impl SharedLobbyState {
         let sessions_to_remove = lobby_state
             .sessions_in_lobby
             .iter()
-            .filter_map(|(id, info)| {
-                if predicate(info) {
-                    Some(id.clone())
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(id, info)| predicate(info).then(|| id.clone()))
             .collect::<Vec<_>>();
         for id in sessions_to_remove {
             let info = lobby_state.sessions_in_lobby.remove(&id);

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -208,15 +208,11 @@ impl SharedLobbyState {
                 }
             })
             .collect::<Vec<_>>();
-        let removed_sessions = sessions_to_remove
-            .into_iter()
-            .filter_map(|id| {
-                let info = lobby_state.sessions_in_lobby.remove(&id)?;
-                Some((id, info))
-            })
-            .collect::<Vec<_>>();
-        for (id, info) in removed_sessions {
-            lobby_state.sessions_out_of_lobby.insert(id, info);
+        for id in sessions_to_remove {
+            let info = lobby_state.sessions_in_lobby.remove(&id);
+            if let Some(info) = info {
+                lobby_state.sessions_out_of_lobby.insert(id, info);
+            }
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -522,7 +522,8 @@ async fn test_various_contributors() {
                 1 => participants::slow_compute(h.as_ref(), c.as_ref(), user).await,
                 2 => participants::wrong_bls(h.as_ref(), c.as_ref(), user).await,
                 _ => {
-                    // only spawn slow lobby ping participants twice, because they make the tests very slow
+                    // only spawn slow lobby ping participants twice, because they make the tests
+                    // very slow
                     participants::well_behaved(h.as_ref(), c.as_ref(), user, i % 20 == 3).await
                 }
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -447,7 +447,7 @@ async fn test_large_lobby() {
             } else {
                 h.create_eth_user().await
             };
-            participants::well_behaved(h.as_ref(), c.as_ref(), user).await
+            participants::well_behaved(h.as_ref(), c.as_ref(), user, false).await
         })
     });
 
@@ -470,7 +470,7 @@ async fn test_large_lobby_with_slow_compute_users() {
         tokio::spawn(async move {
             let user = h.create_gh_user(format!("user {i}")).await;
             if i % 2 == 0 {
-                participants::well_behaved(h.as_ref(), c.as_ref(), user).await
+                participants::well_behaved(h.as_ref(), c.as_ref(), user, false).await
             } else {
                 participants::slow_compute(h.as_ref(), c.as_ref(), user).await
             }
@@ -521,7 +521,10 @@ async fn test_various_contributors() {
                 0 => participants::wrong_ecdsa(h.as_ref(), c.as_ref(), user).await,
                 1 => participants::slow_compute(h.as_ref(), c.as_ref(), user).await,
                 2 => participants::wrong_bls(h.as_ref(), c.as_ref(), user).await,
-                _ => participants::well_behaved(h.as_ref(), c.as_ref(), user).await,
+                _ => {
+                    // only spawn slow lobby ping participants twice, because they make the tests very slow
+                    participants::well_behaved(h.as_ref(), c.as_ref(), user, i % 20 == 3).await
+                }
             }
         })
     });
@@ -655,7 +658,7 @@ async fn test_graceful_restart() {
                 0 => participants::wrong_ecdsa(&h, c.as_ref(), user).await,
                 1 => participants::slow_compute(&h, c.as_ref(), user).await,
                 2 => participants::wrong_bls(&h, c.as_ref(), user).await,
-                _ => participants::well_behaved(&h, c.as_ref(), user).await,
+                _ => participants::well_behaved(&h, c.as_ref(), user, false).await,
             }
         })
     });
@@ -683,7 +686,7 @@ async fn test_graceful_restart() {
                 0 => participants::wrong_ecdsa(&h, c.as_ref(), user).await,
                 1 => participants::slow_compute(&h, c.as_ref(), user).await,
                 2 => participants::wrong_bls(&h, c.as_ref(), user).await,
-                _ => participants::well_behaved(&h, c.as_ref(), user).await,
+                _ => participants::well_behaved(&h, c.as_ref(), user, false).await,
             }
         })
     });


### PR DESCRIPTION

## Motivation
Currently users are getting logged out as soon as they miss the first lobby ping deadline. This is not the specified behavior.

## Solution
Users should be taken out of lobby but not forgotten, until their session deadline passes.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
