### PR TITLE
Updates the default paramter values to match the deployed sequencer.

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,8 +19,8 @@ processes = []
     ETH_MIN_NONCE="0"
     MULTI_CONTRIBUTION="true"
     COMPUTE_DEADLINE="480"
-    LOBBY_CHECKIN_FREQUENCY="30"
-    LOBBY_CHECKIN_TOLERANCE="15"
+    LOBBY_CHECKIN_FREQUENCY="32"
+    LOBBY_CHECKIN_TOLERANCE="16
 
 # ❯ fly secrets list
 # NAME                    DIGEST                  CREATED AT

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -15,12 +15,12 @@ fn duration_from_str(value: &str) -> Result<Duration, ParseIntError> {
 #[group(skip)]
 pub struct Options {
     /// Timeout for participants to contribute to the ceremony in seconds.
-    #[clap(long, env, value_parser=duration_from_str, default_value="180")]
+    #[clap(long, env, value_parser=duration_from_str, default_value="192")]
     pub compute_deadline: Duration,
 
     /// How often participants should ping the server to keep their session
     /// alive in seconds.
-    #[clap(long, env, value_parser=duration_from_str, default_value="30")]
+    #[clap(long, env, value_parser=duration_from_str, default_value="32")]
     pub lobby_checkin_frequency: Duration,
 
     /// How much the ping can be late in seconds
@@ -28,11 +28,11 @@ pub struct Options {
     pub lobby_checkin_tolerance: Duration,
 
     /// How often the server should check for dead sessions in seconds.
-    #[clap(long, env, value_parser=duration_from_str, default_value="5")]
+    #[clap(long, env, value_parser=duration_from_str, default_value="4")]
     pub lobby_flush_interval: Duration,
 
     /// Maximum number of participants in the lobby.
-    #[clap(long, env, default_value = "1000")]
+    #[clap(long, env, default_value = "65536")]
     pub max_lobby_size: usize,
 
     /// How long the session is valid if user doesn't take any actions, in

--- a/src/oauth/ethereum.rs
+++ b/src/oauth/ethereum.rs
@@ -6,12 +6,12 @@ use std::{num::ParseIntError, ops::Deref};
 #[derive(Clone, Debug, PartialEq, Eq, Parser)]
 pub struct EthAuthOptions {
     /// The block height where the users nonce is fetched from.
-    #[clap(long, env, value_parser = dec_to_hex, default_value = "15565180")]
+    #[clap(long, env, value_parser = dec_to_hex, default_value = "16394155")]
     pub eth_nonce_verification_block: String,
 
     /// The minimum nonce required at the specified block height in order to
     /// participate.
-    #[clap(long, env, default_value = "4")]
+    #[clap(long, env, default_value = "3")]
     pub eth_min_nonce: u64,
 
     /// The Ethereum JSON-RPC endpoint to use.


### PR DESCRIPTION
## Motivation

There seems to be much confusion as to what the constants are in the deployed sequencer. This PR just makes the defaults here match [seq.ceremony.ethereum.org](seq.ceremony.ethereum.org). eg #178 and a bunch of issues on the frontend.